### PR TITLE
feat: AE-394: resilient serverless calls with retries and auto-cancellations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,8 @@ $(error "uv is not installed. Please install it before running this Makefile.")
 endif
 
 dev:
-	uv venv && \
-	( \
-	. .venv/bin/activate && \
-	uv sync --all-groups && \
-	echo "Virtual environment created and dependencies installed." && \
-	echo "To activate the virtual environment, run: . .venv/bin/activate" \
-	)
+	uv sync --all-groups
+	make examples
 
 build: requirements
 	docker buildx build \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tetra_rp"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python library for distributed inference and serving of machine learning models"
 authors = [
     { name = "Marut Pandya", email = "pandyamarut@gmail.com" },

--- a/src/tetra_rp/core/resources/serverless.py
+++ b/src/tetra_rp/core/resources/serverless.py
@@ -90,13 +90,16 @@ class ServerlessResource(DeployableResource):
                 continue
 
             # Check against GpuType
-            try:
-                if runpod.get_gpu(id_):
-                    normalized.append(id_)
-                    continue
-            except ValueError as e:
-                log.error(f"`{id_}` {e}")
-                # TODO: get all available GPU types and fuzzy match
+            # try:
+            #     if runpod.get_gpu(id_):
+            #         normalized.append(id_)
+            #         continue
+            # except ValueError as e:
+            #     log.error(f"`{id_}` {e}")
+            #     # TODO: get all available GPU types and fuzzy match
+
+        if not normalized:
+            raise ValueError("Invalid gpuIds provided")
 
         return ",".join(normalized)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1728,7 +1728,7 @@ wheels = [
 
 [[package]]
 name = "tetra-rp"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
fix: simplify make dev that syncs and installs examples (from tetra-examples repo)
fix: passing GPU names aren't supported yet (disabled that until then)
feat: resilient serverless calls with retries and auto-cancellations when unhealthy/throttled