### PR TITLE
Fix wrong linking README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ gpu_config = LiveServerless(
 )
 ```
 
-Refer to the [Configuration Parameters](https://www.google.com/search?q=%23configuration-parameters) section for a full list of available settings.
+Refer to the [Configuration Parameters](#configuration) section for a full list of available settings.
 
 ### Dynamic GPU Provisioning
 


### PR DESCRIPTION
Simply a link was linked to a google seearch instead of linking to the correct title section of configuration parameters
![image](https://github.com/user-attachments/assets/c4c7a43a-cb0e-4ab9-946b-2ddd836b6cad)
