### PR TITLE
fix: implicit load_dotenv() before everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,7 @@ Tetra is well-suited for a variety of AI and data processing tasks, including:
 ```python
 import os
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless
-
-# Load environment variables from .env file
-# Make sure you .env file is in the same directory as your .py file
-load_dotenv()
 
 # Configure RunPod resources
 runpod_config = LiveServerless(name="example-diffusion-server")
@@ -211,12 +206,7 @@ python -m examples.matrix_operations
 ```python
 import os
 import asyncio
-from dotenv import load_dotenv
 from tetra_rp import remote, LiveServerless
-
-# Load environment variables from .env file
-# Make sure you .env file is in the same directory as your .py file
-load_dotenv()
 
 # Configure RunPod resources
 runpod_config = LiveServerless(name="multi-stage-pipeline-server")

--- a/src/tetra_rp/__init__.py
+++ b/src/tetra_rp/__init__.py
@@ -1,6 +1,13 @@
+# Load .env vars from file
+# before everything else
+from dotenv import load_dotenv
+load_dotenv()
+
+
 from .logger import get_logger
 from .client import remote
 from .core.resources import (
+    runpod,
     CudaVersion,
     GpuGroup,
     LiveServerless,
@@ -12,6 +19,7 @@ from .core.resources import (
 __all__ = [
     "get_logger",
     "remote",
+    "runpod",
     "CudaVersion",
     "GpuGroup",
     "LiveServerless",


### PR DESCRIPTION
This removes the need to load it per use and prevents the confusion around `RUNPOD_API_KEY` env var