### PR TITLE
fix: use default release-please PR title pattern

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -12,7 +12,6 @@
       ]
     }
   },
-  "pull-request-title-pattern": "chore: release ${version}",
   "pull-request-header": "Release Please automated release PR",
   "separate-pull-requests": false,
   "changelog-sections": [


### PR DESCRIPTION
release PRs have been written with a constant title `chore: release main` instead of `chore: release v0.0.0` pattern