### PR TITLE
feat: Add idempotent network volume deployment

### DIFF
--- a/src/tetra_rp/core/api/runpod.py
+++ b/src/tetra_rp/core/api/runpod.py
@@ -281,6 +281,30 @@ class RunpodRestClient:
 
         return result
 
+    async def list_network_volumes(self) -> Dict[str, Any]:
+        """
+        List all network volumes in Runpod.
+
+        Returns:
+            List of network volume objects or dict containing networkVolumes key.
+            The API may return either format depending on version.
+        """
+        log.debug("Listing network volumes")
+
+        result = await self._execute_rest(
+            "GET", f"{RUNPOD_REST_API_URL}/networkvolumes"
+        )
+
+        # Handle both list and dict responses
+        if isinstance(result, list):
+            volume_count = len(result)
+        else:
+            volume_count = len(result.get("networkVolumes", []))
+
+        log.debug(f"Listed {volume_count} network volumes")
+
+        return result
+
     async def close(self):
         """Close the HTTP session."""
         if self.session and not self.session.closed:

--- a/src/tetra_rp/core/resources/network_volume.py
+++ b/src/tetra_rp/core/resources/network_volume.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 from enum import Enum
 from typing import Optional
@@ -25,10 +26,11 @@ class DataCenter(str, Enum):
 
 class NetworkVolume(DeployableResource):
     """
-    NetworkVolume resource for creating and managing Runpod netowrk volumes.
+    NetworkVolume resource for creating and managing Runpod network volumes.
 
     This class handles the creation, deployment, and management of network volumes
-    that can be attached to serverless resources.
+    that can be attached to serverless resources. Supports idempotent deployment
+    where multiple volumes with the same name will reuse existing volumes.
 
     """
 
@@ -37,10 +39,23 @@ class NetworkVolume(DeployableResource):
 
     id: Optional[str] = Field(default=None)
     name: Optional[str] = None
-    size: Optional[int] = Field(default=10, gt=0)  # Size in GB
+    size: Optional[int] = Field(default=50, gt=0)  # Size in GB
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}:{self.id}"
+
+    @property
+    def resource_id(self) -> str:
+        """Unique resource ID based on name and datacenter for idempotent behavior."""
+        if self.name:
+            # Use name + datacenter for volumes with names to ensure idempotence
+            resource_type = self.__class__.__name__
+            config_key = f"{self.name}:{self.dataCenterId.value}"
+            hash_obj = hashlib.md5(f"{resource_type}:{config_key}".encode())
+            return f"{resource_type}_{hash_obj.hexdigest()}"
+        else:
+            # Fall back to default behavior for unnamed volumes
+            return super().resource_id
 
     @field_serializer("dataCenterId")
     def serialize_data_center_id(self, value: Optional[DataCenter]) -> Optional[str]:
@@ -61,24 +76,57 @@ class NetworkVolume(DeployableResource):
             raise ValueError("Network volume ID is not set")
         return f"{CONSOLE_BASE_URL}/user/storage"
 
-    async def create_network_volume(self) -> str:
-        """
-        Creates a network volume using the provided configuration.
-        Returns the volume ID.
-        """
-        async with RunpodRestClient() as client:
-            # Create the network volume
-            payload = self.model_dump(exclude_none=True)
-            result = await client.create_network_volume(payload)
-
-        if volume := self.__class__(**result):
-            return volume
-
     def is_deployed(self) -> bool:
         """
         Checks if the network volume resource is deployed and available.
         """
         return self.id is not None
+
+    def _normalize_volumes_response(self, volumes_response) -> list:
+        """Normalize API response to list format."""
+        if isinstance(volumes_response, list):
+            return volumes_response
+        return volumes_response.get("networkVolumes", [])
+
+    def _find_matching_volume(self, existing_volumes: list) -> Optional[dict]:
+        """Find existing volume matching name and datacenter."""
+        for volume_data in existing_volumes:
+            if (
+                volume_data.get("name") == self.name
+                and volume_data.get("dataCenterId") == self.dataCenterId.value
+            ):
+                return volume_data
+        return None
+
+    async def _find_existing_volume(self, client) -> Optional["NetworkVolume"]:
+        """Check for existing volume with same name and datacenter."""
+        if not self.name:
+            return None
+
+        log.debug(f"Checking for existing network volume with name: {self.name}")
+        volumes_response = await client.list_network_volumes()
+        existing_volumes = self._normalize_volumes_response(volumes_response)
+
+        if matching_volume := self._find_matching_volume(existing_volumes):
+            log.info(
+                f"Found existing network volume: {matching_volume.get('id')} with name '{self.name}'"
+            )
+            # Update our instance with the existing volume's ID
+            self.id = matching_volume.get("id")
+            return self
+
+        return None
+
+    async def _create_new_volume(self, client) -> "NetworkVolume":
+        """Create a new network volume."""
+        log.debug(f"Creating new network volume: {self.name or 'unnamed'}")
+        payload = self.model_dump(exclude_none=True)
+        result = await client.create_network_volume(payload)
+
+        if volume := self.__class__(**result):
+            return volume
+
+        raise ValueError("Deployment failed, no volume was created.")
 
     async def deploy(self) -> "DeployableResource":
         """
@@ -91,16 +139,13 @@ class NetworkVolume(DeployableResource):
                 log.debug(f"{self} exists")
                 return self
 
-            # Create the network volume
             async with RunpodRestClient() as client:
-                # Create the network volume
-                payload = self.model_dump(exclude_none=True)
-                result = await client.create_network_volume(payload)
+                # Check for existing volume first
+                if existing_volume := await self._find_existing_volume(client):
+                    return existing_volume
 
-            if volume := self.__class__(**result):
-                return volume
-
-            raise ValueError("Deployment failed, no volume was created.")
+                # No existing volume found, create a new one
+                return await self._create_new_volume(client)
 
         except Exception as e:
             log.error(f"{self} failed to deploy: {e}")

--- a/tests/unit/resources/test_network_volume.py
+++ b/tests/unit/resources/test_network_volume.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for NetworkVolume idempotent behavior.
+"""
+
+from unittest.mock import AsyncMock, patch
+import pytest
+
+from tetra_rp.core.resources.network_volume import NetworkVolume, DataCenter
+
+
+class TestNetworkVolumeIdempotent:
+    """Test NetworkVolume idempotent deployment behavior."""
+
+    @pytest.fixture
+    def mock_runpod_client(self):
+        """Mock RunpodRestClient."""
+        client = AsyncMock()
+        # Mock both methods we need
+        client.list_network_volumes = AsyncMock()
+        client.create_network_volume = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def sample_volume_data(self):
+        """Sample volume data as returned by API."""
+        return {
+            "id": "vol-123456",
+            "name": "deanq",
+            "dataCenterId": "EU-RO-1",
+            "size": 50,
+        }
+
+    @pytest.mark.asyncio
+    async def test_deploy_creates_new_volume_when_none_exists(
+        self, mock_runpod_client, sample_volume_data
+    ):
+        """Test that deploy creates a new volume when none with the same name exists."""
+        # Arrange
+        volume = NetworkVolume(name="deanq", size=50)
+
+        # Mock no existing volumes
+        mock_runpod_client.list_network_volumes.return_value = []
+        mock_runpod_client.create_network_volume.return_value = sample_volume_data
+
+        with patch(
+            "tetra_rp.core.resources.network_volume.RunpodRestClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_runpod_client
+            mock_client_class.return_value.__aexit__ = AsyncMock()
+            # Act
+            result = await volume.deploy()
+
+        # Assert
+        mock_runpod_client.list_network_volumes.assert_called_once()
+        mock_runpod_client.create_network_volume.assert_called_once()
+        assert result.id == "vol-123456"
+        assert result.name == "deanq"
+
+    @pytest.mark.asyncio
+    async def test_deploy_reuses_existing_volume_with_same_name(
+        self, mock_runpod_client, sample_volume_data
+    ):
+        """Test that deploy reuses an existing volume with the same name."""
+        # Arrange
+        volume = NetworkVolume(name="deanq", size=50)
+
+        # Mock existing volume with same name
+        mock_runpod_client.list_network_volumes.return_value = [sample_volume_data]
+
+        with patch(
+            "tetra_rp.core.resources.network_volume.RunpodRestClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_runpod_client
+            mock_client_class.return_value.__aexit__ = AsyncMock()
+            # Act
+            result = await volume.deploy()
+
+        # Assert
+        mock_runpod_client.list_network_volumes.assert_called_once()
+        mock_runpod_client.create_network_volume.assert_not_called()  # Should not create new volume
+        assert result.id == "vol-123456"
+        assert result.name == "deanq"
+
+    @pytest.mark.asyncio
+    async def test_deploy_creates_new_when_existing_has_different_datacenter(
+        self, mock_runpod_client, sample_volume_data
+    ):
+        """Test that deploy creates new volume when existing has different datacenter."""
+        # Arrange
+        volume = NetworkVolume(name="deanq", size=50, dataCenterId=DataCenter.EU_RO_1)
+
+        # Mock existing volume with same name but different datacenter
+        existing_volume_data = {
+            **sample_volume_data,
+            "dataCenterId": "US-WEST-1",  # Different datacenter
+        }
+        mock_runpod_client.list_network_volumes.return_value = [existing_volume_data]
+        mock_runpod_client.create_network_volume.return_value = sample_volume_data
+
+        with patch(
+            "tetra_rp.core.resources.network_volume.RunpodRestClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_runpod_client
+            mock_client_class.return_value.__aexit__ = AsyncMock()
+            # Act
+            result = await volume.deploy()
+
+        # Assert
+        mock_runpod_client.list_network_volumes.assert_called_once()
+        mock_runpod_client.create_network_volume.assert_called_once()  # Should create new volume
+        assert result.id == "vol-123456"
+
+    @pytest.mark.asyncio
+    async def test_deploy_multiple_times_same_name_is_idempotent(
+        self, mock_runpod_client, sample_volume_data
+    ):
+        """Test that multiple deployments with same name are idempotent."""
+        # Arrange
+        volume1 = NetworkVolume(name="deanq", size=50)
+        volume2 = NetworkVolume(name="deanq", size=50)
+
+        # First call returns no existing volumes, second call returns the created volume
+        mock_runpod_client.list_network_volumes.side_effect = [
+            [],  # First call: no existing
+            [sample_volume_data],  # Second call: volume exists
+        ]
+        mock_runpod_client.create_network_volume.return_value = sample_volume_data
+
+        with patch(
+            "tetra_rp.core.resources.network_volume.RunpodRestClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_runpod_client
+            mock_client_class.return_value.__aexit__ = AsyncMock()
+            # Act
+            result1 = await volume1.deploy()
+            result2 = await volume2.deploy()
+
+        # Assert
+        assert mock_runpod_client.list_network_volumes.call_count == 2
+        assert (
+            mock_runpod_client.create_network_volume.call_count == 1
+        )  # Only called once
+        assert result1.id == result2.id == "vol-123456"
+
+    @pytest.mark.asyncio
+    async def test_deploy_without_name_always_creates_new(
+        self, mock_runpod_client, sample_volume_data
+    ):
+        """Test that volumes without names always create new volumes."""
+        # Arrange
+        volume = NetworkVolume(size=50)  # No name
+
+        mock_runpod_client.create_network_volume.return_value = {
+            **sample_volume_data,
+            "name": None,
+        }
+
+        with patch(
+            "tetra_rp.core.resources.network_volume.RunpodRestClient"
+        ) as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_runpod_client
+            mock_client_class.return_value.__aexit__ = AsyncMock()
+            # Act
+            await volume.deploy()
+
+        # Assert
+        mock_runpod_client.list_network_volumes.assert_not_called()  # Should skip lookup for unnamed volumes
+        mock_runpod_client.create_network_volume.assert_called_once()
+
+    def test_resource_id_based_on_name_and_datacenter(self):
+        """Test that resource_id is based on name and datacenter for named volumes."""
+        # Arrange & Act
+        volume1 = NetworkVolume(name="deanq", dataCenterId=DataCenter.EU_RO_1)
+        volume2 = NetworkVolume(name="deanq", dataCenterId=DataCenter.EU_RO_1)
+        volume3 = NetworkVolume(name="different", dataCenterId=DataCenter.EU_RO_1)
+
+        # Assert
+        assert volume1.resource_id == volume2.resource_id  # Same name + datacenter
+        assert volume1.resource_id != volume3.resource_id  # Different name
+
+    def test_resource_id_fallback_for_unnamed_volumes(self):
+        """Test that unnamed volumes use default resource_id behavior."""
+        # Arrange & Act
+        volume1 = NetworkVolume(size=50)  # No name
+        volume2 = NetworkVolume(size=100)  # No name, different size
+
+        # Assert
+        assert (
+            volume1.resource_id != volume2.resource_id
+        )  # Different configs should have different IDs

--- a/uv.lock
+++ b/uv.lock
@@ -2345,7 +2345,7 @@ wheels = [
 
 [[package]]
 name = "tetra-rp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },


### PR DESCRIPTION
- Add list_network_volumes method to RunpodRestClient
- Implement idempotent volume creation that reuses existing volumes with same name/datacenter
- Add resource_id property for consistent volume identification
- Increase default volume size from 10GB to 50GB
- Add comprehensive unit tests for network volume functionality
- Fix typo in NetworkVolume class docstring

Volumes with the same name and datacenter will now reuse existing volumes instead of creating duplicates, enabling truly idempotent deployments.