### PR TITLE
fix: add runpod id to resource configs after deploy or fetch from state

### DIFF
--- a/src/tetra_rp/core/resources/resource_manager.py
+++ b/src/tetra_rp/core/resources/resource_manager.py
@@ -70,6 +70,7 @@ class ResourceManager(SingletonMixin):
 
             log.debug(f"{existing} exists, reusing.")
             log.info(f"URL: {existing.url}")
+            config.id = existing.id
             return existing
 
         if deployed_resource := await config.deploy():

--- a/src/tetra_rp/core/resources/serverless.py
+++ b/src/tetra_rp/core/resources/serverless.py
@@ -252,6 +252,7 @@ class ServerlessResource(DeployableResource):
                 result = await client.create_endpoint(payload)
 
             if endpoint := self.__class__(**result):
+                self.id = endpoint.id
                 return endpoint
 
             raise ValueError("Deployment failed, no endpoint was returned.")


### PR DESCRIPTION
This PR makes a small change to `ServerlessEndpoint` resources and the `ResourceManager` classes.

Currently, after a resource is created, the class that defines it does not have a persistent identifier for its associated entity in Runpod. For example:

```python
gpu_resource = ServerlessEndpoint()

gpu_resource.id # 🔴  this fails
```