### PR TITLE
fix: resolve example with import

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ if __name__ == "__main__":
 ```python
 import asyncio
 from tetra_rp import remote, LiveServerless, GpuGroup, PodTemplate
+import base64
 
 # Advanced GPU configuration with consolidated template overrides
 sd_config = LiveServerless(


### PR DESCRIPTION
If you want to save the image locally, import base64 must be added.  Currently, it is only added to the function `def generate_imate()`.