### PR TITLE
fix(classes): make RemoteClassWrapper and LRUCache picklable

### DIFF
--- a/src/runpod_flash/core/utils/lru_cache.py
+++ b/src/runpod_flash/core/utils/lru_cache.py
@@ -76,7 +76,7 @@ class LRUCache:
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
-        del state["_lock"]
+        state.pop("_lock")
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:

--- a/src/runpod_flash/core/utils/lru_cache.py
+++ b/src/runpod_flash/core/utils/lru_cache.py
@@ -75,7 +75,8 @@ class LRUCache:
         self.set(key, value)
 
     def __getstate__(self) -> Dict[str, Any]:
-        state = self.__dict__.copy()
+        with self._lock:
+            state = self.__dict__.copy()
         state.pop("_lock")
         return state
 

--- a/src/runpod_flash/core/utils/lru_cache.py
+++ b/src/runpod_flash/core/utils/lru_cache.py
@@ -73,3 +73,12 @@ class LRUCache:
     def __setitem__(self, key: str, value: Dict[str, Any]) -> None:
         """Set item using bracket notation."""
         self.set(key, value)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.RLock()

--- a/src/runpod_flash/execute_class.py
+++ b/src/runpod_flash/execute_class.py
@@ -237,6 +237,15 @@ def create_remote_class(
         def __setstate__(self, state: dict) -> None:
             self.__dict__.update(state)
             self._init_lock = asyncio.Lock()
+            # Repopulate the module-level serialization cache so method_proxy
+            # can look up class_code and constructor args after unpickle.
+            if self._cache_key not in _SERIALIZED_CLASS_CACHE:
+                get_or_cache_class_data(
+                    self._class_type,
+                    self._constructor_args,
+                    self._constructor_kwargs,
+                    self._cache_key,
+                )
 
         async def _ensure_initialized(self):
             """Ensure the remote instance is created exactly once, even under concurrent calls."""

--- a/src/runpod_flash/execute_class.py
+++ b/src/runpod_flash/execute_class.py
@@ -225,6 +225,19 @@ def create_remote_class(
                 cls, args, kwargs, self._cache_key
             )
 
+        _UNPICKLABLE_ATTRS = frozenset({"_init_lock", "_stub"})
+
+        def __getstate__(self) -> dict:
+            state = self.__dict__.copy()
+            for attr in self._UNPICKLABLE_ATTRS:
+                state.pop(attr, None)
+            state["_initialized"] = False
+            return state
+
+        def __setstate__(self, state: dict) -> None:
+            self.__dict__.update(state)
+            self._init_lock = asyncio.Lock()
+
         async def _ensure_initialized(self):
             """Ensure the remote instance is created exactly once, even under concurrent calls."""
             # Fast path: already initialized, no lock needed.

--- a/src/runpod_flash/execute_class.py
+++ b/src/runpod_flash/execute_class.py
@@ -237,15 +237,6 @@ def create_remote_class(
         def __setstate__(self, state: dict) -> None:
             self.__dict__.update(state)
             self._init_lock = asyncio.Lock()
-            # Repopulate the module-level serialization cache so method_proxy
-            # can look up class_code and constructor args after unpickle.
-            if self._cache_key not in _SERIALIZED_CLASS_CACHE:
-                get_or_cache_class_data(
-                    self._class_type,
-                    self._constructor_args,
-                    self._constructor_kwargs,
-                    self._cache_key,
-                )
 
         async def _ensure_initialized(self):
             """Ensure the remote instance is created exactly once, even under concurrent calls."""

--- a/tests/unit/core/utils/test_lru_cache.py
+++ b/tests/unit/core/utils/test_lru_cache.py
@@ -1,7 +1,9 @@
 """Tests for LRU cache implementation."""
 
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import cloudpickle
 import pytest
 
 from runpod_flash.core.utils.lru_cache import LRUCache
@@ -296,3 +298,17 @@ class TestLRUCache:
 
         assert not errors
         assert len(cache) == 100
+
+    def test_pickle_roundtrip(self):
+        """LRUCache must survive cloudpickle roundtrip (AE-2745)."""
+        cache = LRUCache(max_size=5)
+        cache.set("a", {"value": 1})
+        cache.set("b", {"value": 2})
+
+        data = cloudpickle.dumps(cache)
+        restored = cloudpickle.loads(data)
+
+        assert restored.get("a") == {"value": 1}
+        assert restored.get("b") == {"value": 2}
+        assert restored.max_size == 5
+        assert type(restored._lock) is type(threading.RLock())

--- a/tests/unit/test_execute_class.py
+++ b/tests/unit/test_execute_class.py
@@ -10,7 +10,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import cloudpickle
 import pytest
 from runpod_flash.core.resources import ServerlessResource
-from runpod_flash.execute_class import create_remote_class, extract_class_code_simple
+from runpod_flash.execute_class import (
+    _SERIALIZED_CLASS_CACHE,
+    create_remote_class,
+    extract_class_code_simple,
+)
 from runpod_flash.protos.remote_execution import FunctionRequest
 
 
@@ -704,3 +708,97 @@ class TestExecuteClassIntegration:
         obj = ReconstructedClass("test")
         assert obj.name == "test"
         assert obj.CLASS_VAR == "class_variable"
+
+
+class TestRemoteClassWrapperPickle:
+    """Test pickle support for RemoteClassWrapper (AE-2745).
+
+    asyncio.Lock is not picklable. RemoteClassWrapper must implement
+    __getstate__/__setstate__ so ResourceManager._save_resources() can
+    persist state via cloudpickle without raising.
+    """
+
+    def setup_method(self):
+        _SERIALIZED_CLASS_CACHE.clear()
+        self.resource_config = ServerlessResource(
+            name="test-resource", image="test-image:latest", cpu=1, memory=512
+        )
+
+    def test_pickle_roundtrip(self):
+        """RemoteClassWrapper instances must survive cloudpickle roundtrip."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(
+            MyModel, self.resource_config, ["numpy"], ["git"], True
+        )
+        instance = RemoteWrapper(42, name="test")
+
+        data = cloudpickle.dumps(instance)
+        restored = cloudpickle.loads(data)
+
+        assert restored._class_type == MyModel
+        assert restored._constructor_args == (42,)
+        assert restored._constructor_kwargs == {"name": "test"}
+        assert restored._dependencies == ["numpy"]
+        assert restored._system_dependencies == ["git"]
+        assert restored._instance_id == instance._instance_id
+        assert not restored._initialized
+        assert type(restored._init_lock) is type(asyncio.Lock())
+
+    def test_pickle_excludes_lock_and_stub(self):
+        """Pickle state must not contain non-picklable fields."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper()
+
+        state = instance.__getstate__()
+
+        assert "_init_lock" not in state
+        assert "_stub" not in state
+        assert state["_initialized"] is False
+
+    def test_pickle_resets_initialized_flag(self):
+        """Unpickled instance must re-initialize on next use."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper()
+        instance._initialized = True
+        instance._stub = "fake_stub"
+
+        data = cloudpickle.dumps(instance)
+        restored = cloudpickle.loads(data)
+
+        assert not restored._initialized
+        assert not hasattr(restored, "_stub")
+        assert type(restored._init_lock) is type(asyncio.Lock())
+
+    def test_pickle_inside_tuple_like_save_resources(self):
+        """Simulate ResourceManager._save_resources() pickle pattern."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper()
+
+        resources = {"uid1": instance}
+        configs = {"uid1": "some_hash"}
+        payload = (resources, configs)
+
+        data = cloudpickle.dumps(payload)
+        restored_resources, restored_configs = cloudpickle.loads(data)
+
+        assert "uid1" in restored_resources
+        assert not restored_resources["uid1"]._initialized

--- a/tests/unit/test_execute_class.py
+++ b/tests/unit/test_execute_class.py
@@ -739,7 +739,7 @@ class TestRemoteClassWrapperPickle:
         data = cloudpickle.dumps(instance)
         restored = cloudpickle.loads(data)
 
-        assert restored._class_type == MyModel
+        assert restored._class_type.__name__ == "MyModel"
         assert restored._constructor_args == (42,)
         assert restored._constructor_kwargs == {"name": "test"}
         assert restored._dependencies == ["numpy"]
@@ -803,38 +803,23 @@ class TestRemoteClassWrapperPickle:
         assert "uid1" in restored_resources
         assert not restored_resources["uid1"]._initialized
 
-    def test_pickle_repopulates_serialization_cache(self):
-        """Unpickle must repopulate _SERIALIZED_CLASS_CACHE so method_proxy works.
-
-        cloudpickle reconstructs dynamic classes with their own globals copy,
-        so __setstate__ populates the cache that method_proxy will read from
-        (same globals dict), not the module-level _SERIALIZED_CLASS_CACHE.
-        Verify from the restored instance's perspective.
-        """
+    def test_pickle_preserves_cache_key_and_class_data(self):
+        """Unpickled instance retains cache_key and class metadata for cache lookup."""
 
         class MyModel:
             def predict(self, x):
                 return x
 
-        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
-        instance = RemoteWrapper()
-        cache_key = instance._cache_key
+        RemoteWrapper = create_remote_class(
+            MyModel, self.resource_config, ["numpy"], ["git"], True
+        )
+        instance = RemoteWrapper(1, tag="v1")
 
         data = cloudpickle.dumps(instance)
-
-        # Simulate a fresh process where the module-level cache is empty.
-        _SERIALIZED_CLASS_CACHE.clear()
-        assert cache_key not in _SERIALIZED_CLASS_CACHE
-
         restored = cloudpickle.loads(data)
 
-        # __setstate__ repopulates the cache visible to the restored class's
-        # methods (cloudpickle gives the reconstructed class its own globals).
-        # Access the cache through the restored class's __setstate__ globals.
-        restored_cache = type(restored).__setstate__.__globals__[
-            "_SERIALIZED_CLASS_CACHE"
-        ]
-        assert cache_key in restored_cache
-        cached = restored_cache.get(cache_key)
-        assert cached["class_code"] is not None
-        assert restored._cache_key == cache_key
+        assert restored._cache_key == instance._cache_key
+        assert restored._clean_class_code == instance._clean_class_code
+        assert restored._class_type.__name__ == "MyModel"
+        assert restored._constructor_args == (1,)
+        assert restored._constructor_kwargs == {"tag": "v1"}

--- a/tests/unit/test_execute_class.py
+++ b/tests/unit/test_execute_class.py
@@ -802,3 +802,39 @@ class TestRemoteClassWrapperPickle:
 
         assert "uid1" in restored_resources
         assert not restored_resources["uid1"]._initialized
+
+    def test_pickle_repopulates_serialization_cache(self):
+        """Unpickle must repopulate _SERIALIZED_CLASS_CACHE so method_proxy works.
+
+        cloudpickle reconstructs dynamic classes with their own globals copy,
+        so __setstate__ populates the cache that method_proxy will read from
+        (same globals dict), not the module-level _SERIALIZED_CLASS_CACHE.
+        Verify from the restored instance's perspective.
+        """
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper()
+        cache_key = instance._cache_key
+
+        data = cloudpickle.dumps(instance)
+
+        # Simulate a fresh process where the module-level cache is empty.
+        _SERIALIZED_CLASS_CACHE.clear()
+        assert cache_key not in _SERIALIZED_CLASS_CACHE
+
+        restored = cloudpickle.loads(data)
+
+        # __setstate__ repopulates the cache visible to the restored class's
+        # methods (cloudpickle gives the reconstructed class its own globals).
+        # Access the cache through the restored class's __setstate__ globals.
+        restored_cache = type(restored).__setstate__.__globals__[
+            "_SERIALIZED_CLASS_CACHE"
+        ]
+        assert cache_key in restored_cache
+        cached = restored_cache.get(cache_key)
+        assert cached["class_code"] is not None
+        assert restored._cache_key == cache_key


### PR DESCRIPTION
## Summary

- `asyncio.Lock` in `RemoteClassWrapper._init_lock` and `threading.RLock` in `LRUCache._lock` are not picklable by cloudpickle
- When `ResourceManager._save_resources()` calls `cloudpickle.dump()`, serialization raises, preventing the state file from being updated
- On next `flash deploy`, ResourceManager has no record of the previous endpoint and creates a duplicate, orphaning the old one
- Added `__getstate__`/`__setstate__` to both `RemoteClassWrapper` and `LRUCache` to exclude unpicklable fields and recreate them on restore
- `RemoteClassWrapper` also resets `_initialized` to `False` on unpickle so the instance re-initializes on next use
- `LRUCache.__getstate__` acquires `_lock` for thread-safe pickling

## Test plan

- [x] `test_pickle_roundtrip` -- full cloudpickle dumps/loads roundtrip preserving all wrapper state
- [x] `test_pickle_excludes_lock_and_stub` -- verifies `_init_lock` and `_stub` absent from `__getstate__` output
- [x] `test_pickle_resets_initialized_flag` -- unpickled instance has `_initialized=False` and no `_stub`
- [x] `test_pickle_inside_tuple_like_save_resources` -- simulates exact `(resources, configs)` tuple pattern from `_save_resources`
- [x] `test_pickle_preserves_cache_key_and_class_data` -- verifies cache_key and class metadata survive roundtrip
- [x] `test_pickle_roundtrip` (LRUCache) -- roundtrip preserving cache contents and max_size