### PR TITLE
fix(classes): harden pickle with cache-miss guard and behavioral tests

### DIFF
--- a/src/runpod_flash/execute_class.py
+++ b/src/runpod_flash/execute_class.py
@@ -285,6 +285,11 @@ def create_remote_class(
                         self._cache_key,
                     )
                     cached_data = _SERIALIZED_CLASS_CACHE.get(self._cache_key)
+                    if cached_data is None:
+                        raise RuntimeError(
+                            f"Failed to populate class cache for key {self._cache_key!r} "
+                            "— class source may not be inspectable"
+                        )
 
                 # Serialize method arguments (these change per call, so no caching)
                 method_args = serialize_args(args)

--- a/src/runpod_flash/execute_class.py
+++ b/src/runpod_flash/execute_class.py
@@ -235,6 +235,13 @@ def create_remote_class(
             return state
 
         def __setstate__(self, state: dict) -> None:
+            """Restore instance after unpickling.
+
+            Only _init_lock needs explicit restoration here. The _stub is
+            intentionally omitted — _ensure_initialized() recreates it on
+            first method call. The serialization cache is preserved by
+            cloudpickle's globals capture of the dynamic class methods.
+            """
             self.__dict__.update(state)
             self._init_lock = asyncio.Lock()
 
@@ -267,8 +274,17 @@ def create_remote_class(
             async def method_proxy(*args, **kwargs):
                 await self._ensure_initialized()
 
-                # Get cached data
+                # Get cached data (normally preserved via cloudpickle globals capture;
+                # fallback re-populates if the cache was evicted or module reloaded)
                 cached_data = _SERIALIZED_CLASS_CACHE.get(self._cache_key)
+                if cached_data is None:
+                    get_or_cache_class_data(
+                        self._class_type,
+                        self._constructor_args,
+                        self._constructor_kwargs,
+                        self._cache_key,
+                    )
+                    cached_data = _SERIALIZED_CLASS_CACHE.get(self._cache_key)
 
                 # Serialize method arguments (these change per call, so no caching)
                 method_args = serialize_args(args)

--- a/tests/unit/core/utils/test_lru_cache.py
+++ b/tests/unit/core/utils/test_lru_cache.py
@@ -311,4 +311,4 @@ class TestLRUCache:
         assert restored.get("a") == {"value": 1}
         assert restored.get("b") == {"value": 2}
         assert restored.max_size == 5
-        assert type(restored._lock) is type(threading.RLock())
+        assert isinstance(restored._lock, type(threading.RLock()))

--- a/tests/unit/test_execute_class.py
+++ b/tests/unit/test_execute_class.py
@@ -863,17 +863,51 @@ class TestRemoteClassWrapperPickle:
 
         RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
         instance = RemoteWrapper(42)
+        cache_key = instance._cache_key
 
         # Clear module-level cache to simulate cold-cache scenario
         _SERIALIZED_CLASS_CACHE.clear()
-        assert instance._cache_key not in _SERIALIZED_CLASS_CACHE
+        assert cache_key not in _SERIALIZED_CLASS_CACHE
 
         mock_stub = AsyncMock()
         mock_stub.execute_class_method.return_value = "result"
         instance._stub = mock_stub
         instance._initialized = True
 
-        result = await instance.predict(10)
+        try:
+            result = await instance.predict(10)
+            assert result == "result"
+            assert cache_key in _SERIALIZED_CLASS_CACHE
+        finally:
+            # Restore cache entry to avoid polluting other tests
+            _SERIALIZED_CLASS_CACHE.clear()
 
-        assert result == "result"
-        assert instance._cache_key in _SERIALIZED_CLASS_CACHE
+    @pytest.mark.asyncio
+    async def test_method_proxy_raises_on_failed_cache_population(self):
+        """method_proxy raises RuntimeError when cache cannot be populated."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper(42)
+
+        _SERIALIZED_CLASS_CACHE.clear()
+
+        mock_stub = AsyncMock()
+        instance._stub = mock_stub
+        instance._initialized = True
+
+        try:
+            # Patch to no-op so cache stays empty after fallback
+            with patch(
+                "runpod_flash.execute_class.get_or_cache_class_data",
+                return_value="",
+            ):
+                with pytest.raises(
+                    RuntimeError, match="Failed to populate class cache"
+                ):
+                    await instance.predict(10)
+        finally:
+            _SERIALIZED_CLASS_CACHE.clear()

--- a/tests/unit/test_execute_class.py
+++ b/tests/unit/test_execute_class.py
@@ -823,3 +823,57 @@ class TestRemoteClassWrapperPickle:
         assert restored._class_type.__name__ == "MyModel"
         assert restored._constructor_args == (1,)
         assert restored._constructor_kwargs == {"tag": "v1"}
+
+    @pytest.mark.asyncio
+    async def test_pickle_method_invocation_with_warm_cache(self):
+        """Calling a method on an unpickled instance works via cloudpickle globals capture."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper(42)
+
+        data = cloudpickle.dumps(instance)
+        restored = cloudpickle.loads(data)
+
+        mock_stub = AsyncMock()
+        mock_stub.execute_class_method.return_value = "result"
+        restored._stub = mock_stub
+        restored._initialized = True
+
+        result = await restored.predict(10)
+
+        assert result == "result"
+        mock_stub.execute_class_method.assert_called_once()
+        request = mock_stub.execute_class_method.call_args[0][0]
+        assert isinstance(request, FunctionRequest)
+        assert request.class_name == "MyModel"
+        assert request.method_name == "predict"
+        assert request.create_new_instance is False
+
+    @pytest.mark.asyncio
+    async def test_method_proxy_repopulates_cold_cache(self):
+        """method_proxy re-populates cache on cache miss (LRU eviction, module reload)."""
+
+        class MyModel:
+            def predict(self, x):
+                return x
+
+        RemoteWrapper = create_remote_class(MyModel, self.resource_config, [], [], True)
+        instance = RemoteWrapper(42)
+
+        # Clear module-level cache to simulate cold-cache scenario
+        _SERIALIZED_CLASS_CACHE.clear()
+        assert instance._cache_key not in _SERIALIZED_CLASS_CACHE
+
+        mock_stub = AsyncMock()
+        mock_stub.execute_class_method.return_value = "result"
+        instance._stub = mock_stub
+        instance._initialized = True
+
+        result = await instance.predict(10)
+
+        assert result == "result"
+        assert instance._cache_key in _SERIALIZED_CLASS_CACHE


### PR DESCRIPTION
## Summary

Follow-up to #306. Addresses QA feedback from @runpod-Henrik.

- Add defensive cache re-population in `method_proxy` for edge cases where cloudpickle globals capture is insufficient (LRU eviction, module reload)
- Add behavioral test that pickles/unpickles a `RemoteClassWrapper` then calls a method on it, proving the cloudpickle globals-capture mechanism works
- Add cold-cache test that clears `_SERIALIZED_CLASS_CACHE` and verifies `method_proxy` re-populates it on miss
- Add docstring to `__setstate__` explaining why only `_init_lock` is restored
- Fix `isinstance` assertion style in LRU cache test (nit from review)

## Test plan

- [x] `test_pickle_method_invocation_with_warm_cache` -- unpickle then call method via mock stub, verify `FunctionRequest` fields
- [x] `test_method_proxy_repopulates_cold_cache` -- clear cache, call method, verify cache re-populated
- [x] All 2585 existing tests pass
- [x] Coverage 85.76% (above 65% threshold)