### PR TITLE
fix(e2e): use --active to skip per-project venv sync in provisioner

### DIFF
--- a/e2e/provisioner.py
+++ b/e2e/provisioner.py
@@ -98,9 +98,15 @@ def provision(
     env = os.environ.copy()
     env["RUNPOD_API_KEY"] = api_key  # explicit — does not depend on autouse fixture
 
+    uv_cmd = ["uv", "run", "--no-project"]
+    if extra_deps:
+        for dep in extra_deps:
+            uv_cmd.extend(["--with", dep])
+    uv_cmd.extend(["flash", "deploy"])
+
     try:
         result = subprocess.run(
-            ["uv", "run", "--no-project", "flash", "deploy"],
+            uv_cmd,
             cwd=tmp_dir,
             env=env,
             capture_output=True,

--- a/e2e/provisioner.py
+++ b/e2e/provisioner.py
@@ -100,7 +100,7 @@ def provision(
 
     try:
         result = subprocess.run(
-            ["uv", "run", "flash", "deploy"],
+            ["uv", "run", "--active", "flash", "deploy"],
             cwd=tmp_dir,
             env=env,
             capture_output=True,

--- a/e2e/provisioner.py
+++ b/e2e/provisioner.py
@@ -100,7 +100,7 @@ def provision(
 
     try:
         result = subprocess.run(
-            ["uv", "run", "--active", "flash", "deploy"],
+            ["uv", "run", "--no-project", "flash", "deploy"],
             cwd=tmp_dir,
             env=env,
             capture_output=True,

--- a/e2e/test_cpu_smoke.py
+++ b/e2e/test_cpu_smoke.py
@@ -71,7 +71,15 @@ class TestCpuSmoke:
             # Exercise the undeploy CLI path; sweep catches any quota leak if this fails.
             try:
                 undeploy = subprocess.run(
-                    ["uv", "run", "--no-project", "flash", "undeploy", WORKER_NAME, "--force"],
+                    [
+                        "uv",
+                        "run",
+                        "--no-project",
+                        "flash",
+                        "undeploy",
+                        WORKER_NAME,
+                        "--force",
+                    ],
                     cwd=tmp_path,
                     env=env,
                     capture_output=True,

--- a/e2e/test_cpu_smoke.py
+++ b/e2e/test_cpu_smoke.py
@@ -44,7 +44,7 @@ class TestCpuSmoke:
 
         try:
             result = subprocess.run(
-                ["uv", "run", "flash", "deploy"],
+                ["uv", "run", "--no-project", "flash", "deploy"],
                 cwd=tmp_path,
                 env=env,
                 capture_output=True,
@@ -71,7 +71,7 @@ class TestCpuSmoke:
             # Exercise the undeploy CLI path; sweep catches any quota leak if this fails.
             try:
                 undeploy = subprocess.run(
-                    ["uv", "run", "flash", "undeploy", WORKER_NAME, "--force"],
+                    ["uv", "run", "--no-project", "flash", "undeploy", WORKER_NAME, "--force"],
                     cwd=tmp_path,
                     env=env,
                     capture_output=True,

--- a/e2e/test_gpu_smoke.py
+++ b/e2e/test_gpu_smoke.py
@@ -68,7 +68,15 @@ class TestGpuSmoke:
         finally:
             try:
                 subprocess.run(
-                    ["uv", "run", "--no-project", "flash", "undeploy", _WORKER_NAME, "--force"],
+                    [
+                        "uv",
+                        "run",
+                        "--no-project",
+                        "flash",
+                        "undeploy",
+                        _WORKER_NAME,
+                        "--force",
+                    ],
                     cwd=tmp_path,
                     env=env,
                     capture_output=True,

--- a/e2e/test_gpu_smoke.py
+++ b/e2e/test_gpu_smoke.py
@@ -43,7 +43,7 @@ class TestGpuSmoke:
 
         try:
             result = subprocess.run(
-                ["uv", "run", "flash", "deploy"],
+                ["uv", "run", "--no-project", "flash", "deploy"],
                 cwd=tmp_path,
                 env=env,
                 capture_output=True,
@@ -68,7 +68,7 @@ class TestGpuSmoke:
         finally:
             try:
                 subprocess.run(
-                    ["uv", "run", "flash", "undeploy", _WORKER_NAME, "--force"],
+                    ["uv", "run", "--no-project", "flash", "undeploy", _WORKER_NAME, "--force"],
                     cwd=tmp_path,
                     env=env,
                     capture_output=True,

--- a/e2e/test_redeploy.py
+++ b/e2e/test_redeploy.py
@@ -67,7 +67,7 @@ async def echo(msg: str = "") -> dict:
 def _deploy(code: str, name: str, tmp_path: Path, env: dict, label: str = "") -> None:
     (tmp_path / "worker.py").write_text(code)
     r = subprocess.run(
-        ["uv", "run", "flash", "deploy"],
+        ["uv", "run", "--no-project", "flash", "deploy"],
         cwd=tmp_path,
         env=env,
         capture_output=True,
@@ -81,7 +81,7 @@ def _deploy(code: str, name: str, tmp_path: Path, env: dict, label: str = "") ->
 def _undeploy(name: str, cwd: Path, env: dict) -> None:
     try:
         subprocess.run(
-            ["uv", "run", "flash", "undeploy", name, "--force"],
+            ["uv", "run", "--no-project", "flash", "undeploy", name, "--force"],
             cwd=cwd,
             env=env,
             capture_output=True,

--- a/e2e/test_rolling_release.py
+++ b/e2e/test_rolling_release.py
@@ -84,8 +84,8 @@ def _deploy_env(api_key: str) -> dict:
     env["RUNPOD_API_KEY"] = api_key
     env["NO_COLOR"] = "1"  # strip ANSI from rich output so stdout is plain text
     env.setdefault(
-        "LOG_LEVEL", "INFO"
-    )  # ensure log.info("Updating endpoint") appears in captured output
+        "LOG_LEVEL", "DEBUG"
+    )  # log.debug("updating endpoint...") in serverless.py — needs DEBUG level
     return env
 
 

--- a/e2e/test_rolling_release.py
+++ b/e2e/test_rolling_release.py
@@ -56,7 +56,7 @@ async def echo(msg: str = "") -> dict:
 def _deploy(code: str, name: str, cwd: Path, env: dict) -> subprocess.CompletedProcess:
     (cwd / "worker.py").write_text(code)
     return subprocess.run(
-        ["uv", "run", "flash", "deploy"],
+        ["uv", "run", "--no-project", "flash", "deploy"],
         cwd=cwd,
         env=env,
         capture_output=True,
@@ -68,7 +68,7 @@ def _deploy(code: str, name: str, cwd: Path, env: dict) -> subprocess.CompletedP
 def _undeploy(name: str, cwd: Path, env: dict) -> None:
     try:
         subprocess.run(
-            ["uv", "run", "flash", "undeploy", name, "--force"],
+            ["uv", "run", "--no-project", "flash", "undeploy", name, "--force"],
             cwd=cwd,
             env=env,
             capture_output=True,


### PR DESCRIPTION
## Summary

- `provisioner.py` ran `uv run flash deploy` in a temp project dir whose `pyproject.toml` declared `runpod-flash @ git+https://github.com/runpod/runpod-flash@<sha>`
- On CI, `uv` tried to sync that dep before running the command, hitting the private repo with no git credentials → `fatal: could not read Username`
- The outer CI venv (`uv sync --all-groups`) already has the correct flash version installed

## Fix

Use `--no-project` so uv skips project discovery entirely and uses the outer CI venv without touching the private git dep. (`--active` alone is not sufficient — uv still reads the pyproject.toml and tries to sync into the active env.)

## Test plan

Re-run the E2E workflow — the provisioner deploy step should no longer fail with a git auth error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)