### PR TITLE
feat(sdk): accept python 3.13 as a target version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     timeout-minutes: 15
     
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     timeout-minutes: 15
     
     steps:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Browse working examples: **[github.com/runpod/flash-examples](https://github.com
 
 ## Requirements
 
-- Python 3.10-3.12
+- Python 3.10-3.13
 - macOS or Linux (Windows support in development)
 - A [RunPod account](https://runpod.io/console) (email must be verified) with an API key
 

--- a/docs/Deployment_Architecture.md
+++ b/docs/Deployment_Architecture.md
@@ -31,7 +31,7 @@ flash build
     │
     ├── 4. Dependency Installation
     │   ├── Install Python packages for linux/x86_64
-    │   ├── Target the app's python_version for wheel ABI selection (3.10 / 3.11 / 3.12)
+    │   ├── Target the app's python_version for wheel ABI selection (3.10 / 3.11 / 3.12 / 3.13)
     │   └── Binary wheels only (no compilation)
     │
     └── 5. Packaging

--- a/docs/Flash_Deploy_Guide.md
+++ b/docs/Flash_Deploy_Guide.md
@@ -6,7 +6,7 @@ This guide walks through deploying a Flash application from local development to
 
 ## Prerequisites
 
-- Python 3.10, 3.11, or 3.12
+- Python 3.10, 3.11, 3.12, or 3.13
 - `pip install runpod-flash`
 - A Runpod account with API key ([get one here](https://docs.runpod.io/get-started/api-keys))
 
@@ -19,9 +19,12 @@ Flash apps ship as a single tarball, so every resource in an app shares one Pyth
 
 | Version | Status | GPU cold-start | Notes |
 |---------|--------|----------------|-------|
-| 3.10 | Supported (EOL 2026-10-31) | +~7 GB alt-Python install | Consider migrating to 3.11 before EOL |
-| 3.11 | Supported | +~7 GB alt-Python install | |
+| 3.10 | Supported (EOL 2026-10-31) | +torch reinstall for cp310 ABI | Consider migrating to 3.11 before EOL |
+| 3.11 | Supported | +torch reinstall for cp311 ABI | |
 | 3.12 | Supported (default) | No overhead | Torch pre-installed in base image |
+| 3.13 | Supported | +torch reinstall for cp313 ABI | Requires torch ≥2.5.0 wheels |
+
+The GPU base image installs Python 3.10-3.13 side-by-side via the deadsnakes PPA, so the "overhead" for non-3.12 targets is the torch wheel reinstall for the matching ABI, not an alternate-interpreter install.
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = { text = "MIT" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ license = { text = "MIT" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ license = { text = "MIT" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
     "cloudpickle>=3.1.1",

--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -1,16 +1,16 @@
 import os
 
 # Worker runtime Python versions. One tarball serves every resource in an app,
-# so all resources must share a single Python version. GPU images ship 3.12
-# with torch pre-installed; 3.10, 3.11, and 3.13 are available via side-by-side
-# install (deadsnakes PPA) in the same base image.
+# so all resources must share a single Python version. The GPU base image
+# ships every supported interpreter (3.10-3.13) side-by-side via the deadsnakes
+# PPA, but torch and CUDA-linked packages are pre-installed only for 3.12.
 WORKER_PYTHON_VERSION: str = "3.12"
 GPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13")
 CPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13")
 
-# Base image ships 3.12 with torch pre-installed; non-3.12 targets reinstall
-# torch side-by-side for the selected interpreter. 3.13 is provided via
-# deadsnakes PPA in the worker image.
+# Non-3.12 targets use the same deadsnakes interpreter already in the image but
+# reinstall torch against the selected interpreter's ABI (cp310/cp311/cp313)
+# during build — the alternate Python itself is not re-downloaded.
 GPU_BASE_IMAGE_PYTHON_VERSION: str = "3.12"
 DEFAULT_PYTHON_VERSION: str = "3.12"
 

--- a/src/runpod_flash/core/resources/constants.py
+++ b/src/runpod_flash/core/resources/constants.py
@@ -2,19 +2,20 @@ import os
 
 # Worker runtime Python versions. One tarball serves every resource in an app,
 # so all resources must share a single Python version. GPU images ship 3.12
-# with torch pre-installed; 3.10 and 3.11 are available via side-by-side
-# install (~7 GB alt-Python overhead) in the same base image.
+# with torch pre-installed; 3.10, 3.11, and 3.13 are available via side-by-side
+# install (deadsnakes PPA) in the same base image.
 WORKER_PYTHON_VERSION: str = "3.12"
-GPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12")
-CPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12")
+GPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13")
+CPU_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13")
 
 # Base image ships 3.12 with torch pre-installed; non-3.12 targets reinstall
-# torch side-by-side for the selected interpreter.
+# torch side-by-side for the selected interpreter. 3.13 is provided via
+# deadsnakes PPA in the worker image.
 GPU_BASE_IMAGE_PYTHON_VERSION: str = "3.12"
 DEFAULT_PYTHON_VERSION: str = "3.12"
 
 # Python versions that can run the flash SDK locally (for flash build, etc.)
-SUPPORTED_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12")
+SUPPORTED_PYTHON_VERSIONS: tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13")
 
 
 def local_python_version() -> str:

--- a/tests/unit/cli/commands/build_utils/test_manifest.py
+++ b/tests/unit/cli/commands/build_utils/test_manifest.py
@@ -1053,3 +1053,9 @@ class TestReconcilePythonVersion:
     def test_unsupported_resource_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
             self._builder()._reconcile_python_version(_make_resources_dict(gpu="3.8"))
+
+    def test_reconcile_python_version_accepts_3_13_declaration(self):
+        resolved = self._builder()._reconcile_python_version(
+            _make_resources_dict(gpu="3.13")
+        )
+        assert resolved == "3.13"

--- a/tests/unit/core/resources/test_constants.py
+++ b/tests/unit/core/resources/test_constants.py
@@ -133,7 +133,7 @@ class TestValidatePythonVersion:
 
     def test_invalid_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
-            validate_python_version("3.9")
+            validate_python_version("3.99")
 
     def test_old_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):

--- a/tests/unit/core/resources/test_constants.py
+++ b/tests/unit/core/resources/test_constants.py
@@ -19,13 +19,13 @@ from runpod_flash.core.resources.constants import (
 
 class TestSupportedPythonVersions:
     def test_supported_versions(self):
-        assert SUPPORTED_PYTHON_VERSIONS == ("3.10", "3.11", "3.12")
+        assert SUPPORTED_PYTHON_VERSIONS == ("3.10", "3.11", "3.12", "3.13")
 
     def test_gpu_python_versions(self):
-        assert GPU_PYTHON_VERSIONS == ("3.10", "3.11", "3.12")
+        assert GPU_PYTHON_VERSIONS == ("3.10", "3.11", "3.12", "3.13")
 
     def test_cpu_python_versions(self):
-        assert CPU_PYTHON_VERSIONS == ("3.10", "3.11", "3.12")
+        assert CPU_PYTHON_VERSIONS == ("3.10", "3.11", "3.12", "3.13")
 
     def test_default_python_version_is_3_12(self):
         assert DEFAULT_PYTHON_VERSION == "3.12"
@@ -40,28 +40,33 @@ class TestGetImageName:
             get_image_name("gpu", "3.12", tag="latest") == "runpod/flash:py3.12-latest"
         )
 
-    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12"])
+    def test_gpu_3_13(self):
+        assert (
+            get_image_name("gpu", "3.13", tag="latest") == "runpod/flash:py3.13-latest"
+        )
+
+    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12", "3.13"])
     def test_gpu_all_supported_versions(self, version):
         assert (
             get_image_name("gpu", version, tag="latest")
             == f"runpod/flash:py{version}-latest"
         )
 
-    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12"])
+    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12", "3.13"])
     def test_cpu_all_supported_versions(self, version):
         assert (
             get_image_name("cpu", version, tag="latest")
             == f"runpod/flash-cpu:py{version}-latest"
         )
 
-    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12"])
+    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12", "3.13"])
     def test_lb_all_supported_versions(self, version):
         assert (
             get_image_name("lb", version, tag="latest")
             == f"runpod/flash-lb:py{version}-latest"
         )
 
-    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12"])
+    @pytest.mark.parametrize("version", ["3.10", "3.11", "3.12", "3.13"])
     def test_lb_cpu_all_supported_versions(self, version):
         assert (
             get_image_name("lb-cpu", version, tag="latest")
@@ -82,7 +87,7 @@ class TestGetImageName:
 
     def test_invalid_python_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
-            get_image_name("gpu", "3.13")
+            get_image_name("gpu", "3.9")
 
     def test_custom_tag(self):
         assert get_image_name("gpu", "3.12", tag="v2.0") == "runpod/flash:py3.12-v2.0"
@@ -128,7 +133,7 @@ class TestValidatePythonVersion:
 
     def test_invalid_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
-            validate_python_version("3.13")
+            validate_python_version("3.9")
 
     def test_old_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):

--- a/tests/unit/core/resources/test_constants.py
+++ b/tests/unit/core/resources/test_constants.py
@@ -87,7 +87,7 @@ class TestGetImageName:
 
     def test_invalid_python_version_raises(self):
         with pytest.raises(ValueError, match="not supported"):
-            get_image_name("gpu", "3.9")
+            get_image_name("gpu", "3.99")
 
     def test_custom_tag(self):
         assert get_image_name("gpu", "3.12", tag="v2.0") == "runpod/flash:py3.12-v2.0"

--- a/tests/unit/resources/test_serverless.py
+++ b/tests/unit/resources/test_serverless.py
@@ -2429,7 +2429,7 @@ class TestServerlessResourcePythonVersion:
     def test_python_version_rejects_invalid(self):
         with pytest.raises(ValueError, match="not supported"):
             ServerlessEndpoint(
-                name="test", imageName="test:latest", python_version="3.9"
+                name="test", imageName="test:latest", python_version="3.99"
             )
 
     def test_python_version_rejects_3_9(self):

--- a/tests/unit/resources/test_serverless.py
+++ b/tests/unit/resources/test_serverless.py
@@ -2429,7 +2429,7 @@ class TestServerlessResourcePythonVersion:
     def test_python_version_rejects_invalid(self):
         with pytest.raises(ValueError, match="not supported"):
             ServerlessEndpoint(
-                name="test", imageName="test:latest", python_version="3.13"
+                name="test", imageName="test:latest", python_version="3.9"
             )
 
     def test_python_version_rejects_3_9(self):


### PR DESCRIPTION
## Summary

Adds Python 3.13 to the SDK's supported target versions. **Strictly additive — non-breaking.** Users opt in by declaring `python_version="3.13"` on a resource; default deploy behavior is unchanged.

## What's in this PR

- `core/resources/constants.py`: add `"3.13"` to `SUPPORTED_PYTHON_VERSIONS`, `GPU_PYTHON_VERSIONS`, `CPU_PYTHON_VERSIONS`. `DEFAULT_PYTHON_VERSION`, `WORKER_PYTHON_VERSION`, and `GPU_BASE_IMAGE_PYTHON_VERSION` remain `"3.12"`.
- `pyproject.toml`: `requires-python = ">=3.10,<3.14"`. Add `Programming Language :: Python :: 3.13` (and `3.12`) classifier.
- Tests: assert `validate_python_version("3.13")` succeeds, `_reconcile_python_version` accepts a `python_version="3.13"` resource declaration, image-name resolution for 3.13 yields `runpod/flash:py3.13-latest`. The previously-existing "invalid version" sentinel tests were flipped from `"3.13"` to `"3.9"`.
- CI: `python-version` matrix in `ci.yml` and `release-please.yml` extended to include `3.13`.

## Why

Extracted from AE-2827 / [#330](https://github.com/runpod/flash/pull/330) so 3.13 support can land independently of the broader match-local-by-default work (which is a BREAKING CHANGE and still in flight on #330). This PR has no breaking changes.

Pairs with [flash-worker #98](https://github.com/runpod-workers/flash/pull/98) which publishes the `py3.13-*` Docker image variants.

## Release coordination

Both PRs can merge to main in any order. The only ordering constraint is between the *release-please* PRs:
1. flash-worker release-please merges first → Docker Hub publishes `runpod/flash:py3.13-{gpu,cpu,lb,lb-cpu}`.
2. flash release-please merges → PyPI publishes new SDK that accepts `python_version="3.13"`.

If the SDK release lands first, no user can hit a broken state until they explicitly set `python_version="3.13"`, which would then pull a missing image tag. Reversing the release order eliminates that window.

## Linear

[AE-3152](https://linear.app/runpod/issue/AE-3152) (child of AE-2827)

## Test plan

- [ ] CI green on 3.10/3.11/3.12/3.13
- [ ] `validate_python_version("3.13")` returns `"3.13"`
- [ ] `_reconcile_python_version` accepts `python_version="3.13"` on a resource
- [ ] After flash-worker py3.13 release → manual end-to-end deploy of a `LiveServerless(python_version="3.13", ...)` succeeds and handler returns a response