### PR TITLE
fix(resources): honor caller-supplied imageName in Live* resources

### DIFF
--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -16,7 +16,18 @@ from .serverless_cpu import CpuServerlessEndpoint
 
 
 class LiveServerlessMixin:
-    """Common mixin for live serverless endpoints that locks the image."""
+    """Common mixin for live serverless endpoints.
+
+    Treats the Flash runtime image as a *default*: if the caller passes an
+    ``imageName`` (e.g. via ``Endpoint(image=...)`` in client mode), that
+    value wins. Otherwise the Flash runtime image for this resource type is
+    used so decorator-mode workloads continue to deploy the Flash wrapper.
+
+    The default is applied via the ``@model_validator(mode="before")`` on each
+    concrete subclass (see ``_apply_default_live_image``); reads and writes of
+    ``imageName`` go through the normal Pydantic field machinery so model
+    serialization, drift detection, and ``setattr`` all stay consistent.
+    """
 
     _image_type: ClassVar[str] = (
         ""  # override in subclasses: 'gpu', 'cpu', 'lb', 'lb-cpu'
@@ -27,13 +38,13 @@ class LiveServerlessMixin:
         python_version = getattr(self, "python_version", None) or DEFAULT_PYTHON_VERSION
         return get_image_name(self._image_type, python_version)
 
-    @property
-    def imageName(self):
-        return self._live_image
 
-    @imageName.setter
-    def imageName(self, value):
-        pass
+def _apply_default_live_image(data: dict, image_type: str) -> dict:
+    """Set the Flash runtime image as a default if the caller didn't supply one."""
+    if not data.get("imageName"):
+        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
+        data["imageName"] = get_image_name(image_type, python_version)
+    return data
 
 
 class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
@@ -44,10 +55,8 @@ class LiveServerless(LiveServerlessMixin, ServerlessEndpoint):
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
-        """Set default GPU image for Live Serverless."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("gpu", python_version)
-        return data
+        """Default to the GPU Flash runtime image when none is supplied."""
+        return _apply_default_live_image(data, "gpu")
 
 
 class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
@@ -58,10 +67,8 @@ class CpuLiveServerless(LiveServerlessMixin, CpuServerlessEndpoint):
     @model_validator(mode="before")
     @classmethod
     def set_live_serverless_template(cls, data: dict):
-        """Set default CPU image for Live Serverless."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("cpu", python_version)
-        return data
+        """Default to the CPU Flash runtime image when none is supplied."""
+        return _apply_default_live_image(data, "cpu")
 
 
 class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
@@ -72,10 +79,8 @@ class LiveLoadBalancer(LiveServerlessMixin, LoadBalancerSlsResource):
     @model_validator(mode="before")
     @classmethod
     def set_live_lb_template(cls, data: dict):
-        """Set default image for Live Load-Balanced endpoint."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("lb", python_version)
-        return data
+        """Default to the LB Flash runtime image when none is supplied."""
+        return _apply_default_live_image(data, "lb")
 
 
 class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
@@ -86,7 +91,5 @@ class CpuLiveLoadBalancer(LiveServerlessMixin, CpuLoadBalancerSlsResource):
     @model_validator(mode="before")
     @classmethod
     def set_live_cpu_lb_template(cls, data: dict):
-        """Set default CPU image for Live Load-Balanced endpoint."""
-        python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
-        data["imageName"] = get_image_name("lb-cpu", python_version)
-        return data
+        """Default to the CPU LB Flash runtime image when none is supplied."""
+        return _apply_default_live_image(data, "lb-cpu")

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -1,5 +1,5 @@
 # Ship serverless code as you write it. No builds, no deploys -- just run.
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import model_validator
 
@@ -39,8 +39,13 @@ class LiveServerlessMixin:
         return get_image_name(self._image_type, python_version)
 
 
-def _apply_default_live_image(data, image_type: str):
-    """Set the Flash runtime image as a default if the caller didn't supply one."""
+def _apply_default_live_image(data: Any, image_type: str):
+    """Set the Flash runtime image as a default if the caller didn't supply one.
+
+    ``data`` is annotated ``Any`` because Pydantic's ``@model_validator(mode="before")``
+    can receive either the raw input dict or an already-constructed model instance
+    (on revalidation). The ``isinstance(data, dict)`` guard handles the latter.
+    """
     if not isinstance(data, dict):
         return data
     if not data.get("imageName"):

--- a/src/runpod_flash/core/resources/live_serverless.py
+++ b/src/runpod_flash/core/resources/live_serverless.py
@@ -39,8 +39,10 @@ class LiveServerlessMixin:
         return get_image_name(self._image_type, python_version)
 
 
-def _apply_default_live_image(data: dict, image_type: str) -> dict:
+def _apply_default_live_image(data, image_type: str):
     """Set the Flash runtime image as a default if the caller didn't supply one."""
+    if not isinstance(data, dict):
+        return data
     if not data.get("imageName"):
         python_version = data.get("python_version") or DEFAULT_PYTHON_VERSION
         data["imageName"] = get_image_name(image_type, python_version)

--- a/src/runpod_flash/endpoint.py
+++ b/src/runpod_flash/endpoint.py
@@ -404,6 +404,12 @@ class Endpoint:
         self.execution_timeout_ms = execution_timeout_ms
         self.flashboot = flashboot
         self.image = image
+        if image is not None:
+            log.info(
+                "Endpoint %r: using user-supplied image %r (overrides Flash runtime image)",
+                name,
+                image,
+            )
         self._explicit_scaler_type = scaler_type
         self.scaler_value = scaler_value
         self.template = template

--- a/tests/integration/test_cpu_disk_sizing.py
+++ b/tests/integration/test_cpu_disk_sizing.py
@@ -244,28 +244,28 @@ class TestCpuDiskSizingIntegration:
         assert "cpu5c-1-2: max 15GB" in error_msg
 
 
-class TestLiveServerlessImageLockingIntegration:
-    """Test image locking integration in live serverless variants."""
+class TestLiveServerlessImageIntegration:
+    """Test image default + override behavior in live serverless variants (AE-3153)."""
 
     def test_live_serverless_image_consistency(self):
-        """Test that LiveServerless variants maintain image consistency."""
+        """LiveServerless variants default to distinct Flash runtime images."""
         gpu_live = LiveServerless(name="gpu-live")
         cpu_live = CpuLiveServerless(name="cpu-live")
 
-        # Verify different images are used
+        # Verify different default images are used per resource type.
         assert gpu_live.imageName != cpu_live.imageName
         assert "flash:" in gpu_live.imageName
         assert "flash-cpu:" in cpu_live.imageName
 
-        # Verify images remain locked despite attempts to change
-        original_gpu_image = gpu_live.imageName
-        original_cpu_image = cpu_live.imageName
+    def test_live_serverless_image_override_via_constructor(self):
+        """Caller-supplied imageName overrides the Flash runtime default (AE-3153)."""
+        gpu_live = LiveServerless(name="gpu-live", imageName="custom/image:latest")
+        cpu_live = CpuLiveServerless(
+            name="cpu-live", imageName="custom/cpu-image:latest"
+        )
 
-        gpu_live.imageName = "custom/image:latest"
-        cpu_live.imageName = "custom/image:latest"
-
-        assert gpu_live.imageName == original_gpu_image
-        assert cpu_live.imageName == original_cpu_image
+        assert gpu_live.imageName == "custom/image:latest"
+        assert cpu_live.imageName == "custom/cpu-image:latest"
 
     def test_live_serverless_template_integration(self):
         """Test live serverless template integration with disk sizing."""

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -116,19 +116,17 @@ class TestRemoteWithLoadBalancerIntegration:
         assert "flash-lb" in lb.imageName
         assert echo.__remote_config__["method"] == "POST"
 
-    def test_live_load_balancer_image_locked(self):
-        """Test that LiveLoadBalancer locks the image to Flash LB image."""
-        lb = LiveLoadBalancer(name="test-api")
+    def test_live_load_balancer_image_default_and_override(self):
+        """LiveLoadBalancer defaults to the Flash LB image but honors overrides (AE-3153)."""
+        # Default path: no caller image -> Flash LB runtime image.
+        default_lb = LiveLoadBalancer(name="test-api-default")
+        assert "flash-lb" in default_lb.imageName
 
-        # Verify image is locked and cannot be overridden
-        original_image = lb.imageName
-        assert "flash-lb" in original_image
-
-        # Try to set a different image (should be ignored due to property)
-        lb.imageName = "custom-image:latest"
-
-        # Image should still be locked to Flash
-        assert lb.imageName == original_image
+        # Override path: caller-supplied image is used verbatim.
+        custom_lb = LiveLoadBalancer(
+            name="test-api-custom", imageName="custom-image:latest"
+        )
+        assert custom_lb.imageName == "custom-image:latest"
 
     def test_load_balancer_vs_queue_based_endpoints(self):
         """Test that LB and QB endpoints have different characteristics."""

--- a/tests/integration/test_lb_remote_execution.py
+++ b/tests/integration/test_lb_remote_execution.py
@@ -128,6 +128,10 @@ class TestRemoteWithLoadBalancerIntegration:
         )
         assert custom_lb.imageName == "custom-image:latest"
 
+        # Guard against a future regression where both paths collapse to the
+        # same default (e.g. the override branch reverting to a no-op).
+        assert default_lb.imageName != custom_lb.imageName
+
     def test_load_balancer_vs_queue_based_endpoints(self):
         """Test that LB and QB endpoints have different characteristics."""
         from runpod_flash import ServerlessEndpoint

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -194,12 +194,12 @@ class TestLiveServerlessMixin:
         assert "flash-cpu:" in live_serverless._live_image
 
     def test_image_name_property_gpu(self):
-        """Test LiveServerless imageName property returns locked image."""
+        """LiveServerless defaults imageName to the Flash runtime image when none supplied."""
         live_serverless = LiveServerless(name="test")
         assert live_serverless.imageName == live_serverless._live_image
 
     def test_image_name_property_cpu(self):
-        """Test CpuLiveServerless imageName property returns locked image."""
+        """CpuLiveServerless defaults imageName to the Flash runtime image when none supplied."""
         live_serverless = CpuLiveServerless(name="test")
         assert live_serverless.imageName == live_serverless._live_image
 
@@ -222,6 +222,12 @@ class TestLiveServerlessMixin:
         """CpuLiveLoadBalancer honors caller-supplied imageName (AE-3153)."""
         lb = CpuLiveLoadBalancer(name="test", imageName="byo/cpu-lb-image:v1")
         assert lb.imageName == "byo/cpu-lb-image:v1"
+
+    def test_default_image_validator_passes_through_non_dict(self):
+        """`mode='before'` validators must tolerate non-dict input (e.g., model instances)."""
+        original = LiveServerless(name="test", imageName="byo/image:v1")
+        revalidated = LiveServerless.model_validate(original)
+        assert revalidated.imageName == "byo/image:v1"
 
 
 class TestLiveServerlessPythonVersion:

--- a/tests/unit/resources/test_live_serverless.py
+++ b/tests/unit/resources/test_live_serverless.py
@@ -45,19 +45,20 @@ class TestLiveServerless:
         assert live_serverless.template.containerDiskInGb == 64
         assert "flash:" in live_serverless.imageName  # GPU image
 
-    def test_live_serverless_image_locked(self):
-        """Test LiveServerless imageName is locked to GPU image."""
+    def test_live_serverless_image_override_via_constructor(self):
+        """LiveServerless accepts a caller-supplied imageName (AE-3153)."""
         live_serverless = LiveServerless(
             name="example_gpu_live_serverless",
+            imageName="custom/image:latest",
         )
 
-        original_image = live_serverless.imageName
+        # User-supplied image wins over the Flash runtime default.
+        assert live_serverless.imageName == "custom/image:latest"
 
-        # Attempt to change imageName - should be ignored
-        live_serverless.imageName = "custom/image:latest"
-
-        assert live_serverless.imageName == original_image
-        assert "flash:" in live_serverless.imageName  # Still GPU image
+    def test_live_serverless_image_default_unchanged(self):
+        """LiveServerless still defaults to the Flash GPU runtime image."""
+        live_serverless = LiveServerless(name="example_gpu_live_serverless")
+        assert "flash:" in live_serverless.imageName
 
     def test_live_serverless_with_custom_template(self):
         """Test LiveServerless with custom template."""
@@ -113,20 +114,23 @@ class TestCpuLiveServerless:
         assert live_serverless.template is not None
         assert live_serverless.template.containerDiskInGb == 10  # Min of 10 and 30
 
-    def test_cpu_live_serverless_image_locked(self):
-        """Test CpuLiveServerless imageName is locked to CPU image."""
+    def test_cpu_live_serverless_image_override_via_constructor(self):
+        """CpuLiveServerless accepts a caller-supplied imageName (AE-3153)."""
+        live_serverless = CpuLiveServerless(
+            name="example_cpu_live_serverless",
+            instanceIds=[CpuInstanceType.CPU3G_1_4],
+            imageName="custom/image:latest",
+        )
+
+        assert live_serverless.imageName == "custom/image:latest"
+
+    def test_cpu_live_serverless_image_default_unchanged(self):
+        """CpuLiveServerless still defaults to the Flash CPU runtime image."""
         live_serverless = CpuLiveServerless(
             name="example_cpu_live_serverless",
             instanceIds=[CpuInstanceType.CPU3G_1_4],
         )
-
-        original_image = live_serverless.imageName
-
-        # Attempt to change imageName - should be ignored
-        live_serverless.imageName = "custom/image:latest"
-
-        assert live_serverless.imageName == original_image
-        assert "flash-cpu:" in live_serverless.imageName  # Still CPU image
+        assert "flash-cpu:" in live_serverless.imageName
 
     def test_cpu_live_serverless_validation_failure(self):
         """Test CpuLiveServerless validation fails with excessive disk size."""
@@ -199,23 +203,25 @@ class TestLiveServerlessMixin:
         live_serverless = CpuLiveServerless(name="test")
         assert live_serverless.imageName == live_serverless._live_image
 
-    def test_image_name_setter_ignored_gpu(self):
-        """Test LiveServerless imageName setter is ignored."""
-        live_serverless = LiveServerless(name="test")
-        original_image = live_serverless.imageName
+    def test_image_name_override_gpu(self):
+        """LiveServerless honors caller-supplied imageName (AE-3153)."""
+        live_serverless = LiveServerless(name="test", imageName="byo/image:v1")
+        assert live_serverless.imageName == "byo/image:v1"
 
-        live_serverless.imageName = "should-be-ignored"
+    def test_image_name_override_cpu(self):
+        """CpuLiveServerless honors caller-supplied imageName (AE-3153)."""
+        live_serverless = CpuLiveServerless(name="test", imageName="byo/cpu-image:v1")
+        assert live_serverless.imageName == "byo/cpu-image:v1"
 
-        assert live_serverless.imageName == original_image
+    def test_image_name_override_lb(self):
+        """LiveLoadBalancer honors caller-supplied imageName (AE-3153)."""
+        lb = LiveLoadBalancer(name="test", imageName="byo/lb-image:v1")
+        assert lb.imageName == "byo/lb-image:v1"
 
-    def test_image_name_setter_ignored_cpu(self):
-        """Test CpuLiveServerless imageName setter is ignored."""
-        live_serverless = CpuLiveServerless(name="test")
-        original_image = live_serverless.imageName
-
-        live_serverless.imageName = "should-be-ignored"
-
-        assert live_serverless.imageName == original_image
+    def test_image_name_override_cpu_lb(self):
+        """CpuLiveLoadBalancer honors caller-supplied imageName (AE-3153)."""
+        lb = CpuLiveLoadBalancer(name="test", imageName="byo/cpu-lb-image:v1")
+        assert lb.imageName == "byo/cpu-lb-image:v1"
 
 
 class TestLiveServerlessPythonVersion:

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -337,6 +337,31 @@ class TestBuildResourceConfig:
         assert isinstance(config, LiveServerless)
 
     @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"})
+    def test_endpoint_image_passed_to_live_resource(self):
+        """End-to-end: Endpoint(image=...) must reach the live resource's imageName.
+
+        Covers the AE-3153 headline bug path -- previous regressions were only
+        visible through Endpoint._build_resource_config, not by constructing
+        Live* resources directly.
+        """
+        ep = Endpoint(name="byoi", image="user/custom:v1", gpu=GpuGroup.ANY)
+        config = ep._build_resource_config()
+        from runpod_flash.core.resources.live_serverless import LiveServerless
+
+        assert isinstance(config, LiveServerless)
+        assert config.imageName == "user/custom:v1"
+
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"})
+    def test_endpoint_no_image_uses_flash_runtime_default(self):
+        """Without image=, the live resource still defaults to the Flash runtime image."""
+        ep = Endpoint(name="default-img", gpu=GpuGroup.ANY)
+        config = ep._build_resource_config()
+        from runpod_flash.core.resources.live_serverless import LiveServerless
+
+        assert isinstance(config, LiveServerless)
+        assert "flash" in config.imageName
+
+    @patch.dict(os.environ, {"FLASH_IS_LIVE_PROVISIONING": "true"})
     def test_config_passes_idle_timeout(self):
         ep = Endpoint(name="test", idle_timeout=10, workers=(1, 5))
         config = ep._build_resource_config()


### PR DESCRIPTION
## Summary

- `LiveServerlessMixin` and the `Live*`/`CpuLive*` subclasses silently swallowed caller-supplied `imageName`: the setter was a no-op and the `@model_validator(mode="before")` hooks unconditionally rewrote `data["imageName"]` to the Flash runtime image. This made `Endpoint(image=...)` client-mode unreachable under `FLASH_IS_LIVE_PROVISIONING=true` — user image was discarded, Flash's wrapper deployed instead, jobs returned empty envelopes.
- Treat the Flash runtime image as a default, not a lock: only assign `data["imageName"]` when the caller didn't supply one. Drop the property override so reads/writes use Pydantic's normal field machinery (keeps `model_dump`, drift hashes, and `setattr` consistent).
- `Endpoint.__init__` now logs an info line when the caller passes `image=` so the substitution choice is observable.
- Refs [AE-3153](https://linear.app/runpod/issue/AE-3153).

## Behavior changes (for release notes)

- **Post-construction `imageName` assignment is no longer silently dropped.** Before this fix, `live.imageName = "x"` on a `Live*`/`CpuLive*` instance was a no-op because `imageName` was a read-only property. It is now a normal Pydantic field — assignments take effect. No callers in the repo relied on the old behavior, but any user workaround that defensively reset `imageName` post-construction expecting it to be ignored will now write through.
- **Previously broken endpoints will re-deploy on next `flash deploy`.** `imageName` is not in `_hashed_fields`, so `config_hash` is stable across this fix. But for users who hit the bug (`Endpoint(image="user/...")` provisioning a template pointing at the Flash wrapper image instead), the deployed template content changes after this fix and the resource manager will re-create the template on the next deploy. The new template ID will differ — expected as part of broken → working.

## Test plan

- [x] `make quality-check` passes (2696 unit + 53 integration tests, coverage 85.4%).
- [x] New / updated tests cover both paths for all four `Live*` classes:
  - default path: no `imageName` -> Flash runtime image
  - override path: caller `imageName="custom/..."` -> stored verbatim
- [x] End-to-end `Endpoint(image=...)` -> `_build_resource_config()` coverage (`test_endpoint.py::TestBuildResourceConfig::test_endpoint_image_passed_to_live_resource`) — closes the gap between unit coverage and the user-visible bug path.
- [x] Decorator-mode regression check: `LiveServerless(name=...)` (no image) still resolves to `runpod/flash:py3.12-*`.
- [ ] Manual smoke: `Endpoint(name=..., image="runpod/worker-v1-vllm:v2.18.1", gpu=...)` under `FLASH_IS_LIVE_PROVISIONING=true` provisions a template whose `imageName` matches the supplied value. **Blocked by [SLS-132](https://linear.app/runpod/issue/SLS-132/flash-standalone-python-workerpy-fails-with-deploy-first-live)** — standalone `python worker.py` dead-ends on a "deploy first" sentinel regression from #324 before reaching the live-provisioning path. End-to-end verification of this fix has to wait until SLS-132 unblocks the live path; unit/integration coverage above exercises the same code through `_build_resource_config()` in the meantime.