### PR TITLE
fix(endpoint): retry EndpointJob.wait() on transient httpx errors

### DIFF
--- a/src/runpod_flash/endpoint.py
+++ b/src/runpod_flash/endpoint.py
@@ -27,6 +27,10 @@ _POLL_INITIAL_INTERVAL = 0.25
 _POLL_MAX_INTERVAL = 5.0
 _POLL_BACKOFF_FACTOR = 1.5
 
+# max consecutive transient httpx errors tolerated during wait() polling
+# before re-raising. resets on any successful poll.
+_POLL_MAX_CONSECUTIVE_ERRORS = 5
+
 
 class _ClientCoroutine:
     """wraps a coroutine from a client-mode HTTP call.
@@ -137,8 +141,11 @@ class EndpointJob:
         import asyncio
         import time
 
+        import httpx
+
         deadline = (time.monotonic() + timeout) if timeout is not None else None
         interval = _POLL_INITIAL_INTERVAL
+        consecutive_errors = 0
 
         while not self.done:
             if deadline is not None and time.monotonic() >= deadline:
@@ -152,7 +159,27 @@ class EndpointJob:
                     f"job {self.id} did not complete within {timeout}s "
                     f"(last status: {self._data.get('status', 'UNKNOWN')})"
                 )
-            await self.status()
+            try:
+                await self.status()
+            except (httpx.TransportError, httpx.TimeoutException) as e:
+                # transient network / protocol / timeout error from the
+                # runpod api. the underlying job is still healthy, so back
+                # off and retry rather than aborting wait().
+                # HTTPStatusError (4xx/5xx from raise_for_status) is NOT
+                # caught here: 4xx auth/config bugs must fail loud.
+                consecutive_errors += 1
+                log.debug(
+                    "transient httpx error polling job %s (%d/%d): %s",
+                    self.id,
+                    consecutive_errors,
+                    _POLL_MAX_CONSECUTIVE_ERRORS,
+                    e,
+                )
+                if consecutive_errors >= _POLL_MAX_CONSECUTIVE_ERRORS:
+                    raise
+                interval = min(interval * _POLL_BACKOFF_FACTOR, _POLL_MAX_INTERVAL)
+                continue
+            consecutive_errors = 0
             interval = min(interval * _POLL_BACKOFF_FACTOR, _POLL_MAX_INTERVAL)
 
         return self

--- a/src/runpod_flash/endpoint.py
+++ b/src/runpod_flash/endpoint.py
@@ -130,7 +130,9 @@ class EndpointJob:
         """poll until the job reaches a terminal status.
 
         uses exponential backoff between polls. updates _data in place
-        and returns self.
+        and returns self. when timeout is set, the deadline is bounded
+        across the status() call itself via asyncio.wait_for, so the
+        underlying httpx timeout cannot exceed the user-supplied deadline.
 
         args:
             timeout: max seconds to wait. None means wait indefinitely.
@@ -160,15 +162,34 @@ class EndpointJob:
                     f"(last status: {self._data.get('status', 'UNKNOWN')})"
                 )
             try:
-                await self.status()
-            except (httpx.TransportError, httpx.TimeoutException) as e:
-                # transient network / protocol / timeout error from the
-                # runpod api. the underlying job is still healthy, so back
-                # off and retry rather than aborting wait().
-                # HTTPStatusError (4xx/5xx from raise_for_status) is NOT
-                # caught here: 4xx auth/config bugs must fail loud.
+                if deadline is not None:
+                    # bound status() by remaining deadline so the user-supplied
+                    # timeout is authoritative even when _api_get's own httpx
+                    # timeout would otherwise exceed it.
+                    remaining = deadline - time.monotonic()
+                    await asyncio.wait_for(self.status(), timeout=remaining)
+                else:
+                    await self.status()
+            except asyncio.TimeoutError:
+                # deadline tripped while status() was in-flight.
+                raise TimeoutError(
+                    f"job {self.id} did not complete within {timeout}s "
+                    f"(last status: {self._data.get('status', 'UNKNOWN')})"
+                ) from None
+            except httpx.TransportError as e:
+                # transient network / protocol / timeout error from the runpod
+                # api. httpx.TimeoutException is a subclass of TransportError,
+                # so a single catch covers both. the underlying job is still
+                # healthy, so back off and retry rather than aborting wait().
+                # HTTPStatusError (4xx/5xx from raise_for_status) is NOT caught
+                # here: auth/config bugs must fail loud.
                 consecutive_errors += 1
-                log.debug(
+                # first retry surfaces at INFO so operators see why wait() is
+                # taking longer than expected; subsequent retries at DEBUG to
+                # avoid log spam during sustained outages.
+                level = logging.INFO if consecutive_errors == 1 else logging.DEBUG
+                log.log(
+                    level,
                     "transient httpx error polling job %s (%d/%d): %s",
                     self.id,
                     consecutive_errors,

--- a/tests/unit/test_endpoint_client.py
+++ b/tests/unit/test_endpoint_client.py
@@ -301,9 +301,16 @@ class TestEndpointJobWaitTransientErrors:
         assert ep._api_get.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_timeout_still_authoritative(self):
-        """when deadline is hit before threshold, raise TimeoutError not httpx error."""
+    async def test_timeout_still_authoritative(self, fast_poll, monkeypatch):
+        """when deadline is hit before threshold, raise TimeoutError not httpx error.
+
+        Raises the threshold above the number of retries the deadline allows, so
+        the test actually exercises the retry path (multiple suppressed httpx
+        errors) before the deadline trips -- not just the pre-sleep guard.
+        """
         import httpx
+
+        monkeypatch.setattr("runpod_flash.endpoint._POLL_MAX_CONSECUTIVE_ERRORS", 1000)
 
         ep, job = self._make_job()
         ep._api_get = AsyncMock(
@@ -311,7 +318,11 @@ class TestEndpointJobWaitTransientErrors:
         )
 
         with pytest.raises(TimeoutError, match="did not complete within"):
-            await job.wait(timeout=0.1)
+            await job.wait(timeout=0.05)
+
+        # proves the retry path was exercised: status() was called and the
+        # httpx error was suppressed at least once before the deadline tripped.
+        assert ep._api_get.call_count >= 2
 
 
 # -- Endpoint.run / runsync / cancel --

--- a/tests/unit/test_endpoint_client.py
+++ b/tests/unit/test_endpoint_client.py
@@ -199,6 +199,121 @@ class TestEndpointJobWait:
                 await job.wait(timeout=0.3)
 
 
+@pytest.fixture
+def fast_poll(monkeypatch):
+    """shrink the poll intervals so retry tests don't sit on real sleeps."""
+    monkeypatch.setattr("runpod_flash.endpoint._POLL_INITIAL_INTERVAL", 0.001)
+    monkeypatch.setattr("runpod_flash.endpoint._POLL_MAX_INTERVAL", 0.005)
+
+
+class TestEndpointJobWaitTransientErrors:
+    """retry behavior for transient httpx errors during wait() polling (AE-3154)."""
+
+    @staticmethod
+    def _make_job():
+        ep = Endpoint(id="ep-1")
+        ep._endpoint_url = "https://api.runpod.ai/v2/ep-1"
+        job = EndpointJob({"id": "j-1", "status": "IN_QUEUE"}, ep)
+        return ep, job
+
+    @pytest.mark.asyncio
+    async def test_transient_error_then_success(self, fast_poll):
+        """one RemoteProtocolError then COMPLETED — wait() returns normally."""
+        import httpx
+
+        ep, job = self._make_job()
+
+        side_effects = [
+            httpx.RemoteProtocolError("server disconnected"),
+            {"id": "j-1", "status": "COMPLETED", "output": {"r": 1}},
+        ]
+        ep._api_get = AsyncMock(side_effect=side_effects)
+
+        result = await job.wait()
+
+        assert result is job
+        assert job._data["status"] == "COMPLETED"
+        assert job.output == {"r": 1}
+        assert ep._api_get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_repeated_transient_errors_exceed_threshold(self, fast_poll):
+        """5 consecutive RemoteProtocolErrors — wait() re-raises the httpx error."""
+        import httpx
+
+        from runpod_flash.endpoint import _POLL_MAX_CONSECUTIVE_ERRORS
+
+        ep, job = self._make_job()
+        ep._api_get = AsyncMock(
+            side_effect=httpx.RemoteProtocolError("server disconnected")
+        )
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            await job.wait()
+
+        assert ep._api_get.call_count == _POLL_MAX_CONSECUTIVE_ERRORS
+
+    @pytest.mark.asyncio
+    async def test_counter_resets_on_successful_poll(self, fast_poll):
+        """error bursts under the threshold separated by successes do not abort."""
+        import httpx
+
+        ep, job = self._make_job()
+
+        side_effects = [
+            httpx.RemoteProtocolError("drop 1"),
+            httpx.RemoteProtocolError("drop 2"),
+            {"id": "j-1", "status": "IN_PROGRESS"},
+            httpx.RemoteProtocolError("drop 3"),
+            httpx.RemoteProtocolError("drop 4"),
+            httpx.RemoteProtocolError("drop 5"),
+            httpx.RemoteProtocolError("drop 6"),
+            {"id": "j-1", "status": "IN_PROGRESS"},
+            {"id": "j-1", "status": "COMPLETED", "output": {"r": 1}},
+        ]
+        ep._api_get = AsyncMock(side_effect=side_effects)
+
+        result = await job.wait()
+
+        assert result is job
+        assert job._data["status"] == "COMPLETED"
+        assert ep._api_get.call_count == len(side_effects)
+
+    @pytest.mark.asyncio
+    async def test_http_status_error_not_swallowed(self, fast_poll):
+        """4xx HTTPStatusError must propagate immediately (auth/config bugs)."""
+        import httpx
+
+        ep, job = self._make_job()
+
+        request = httpx.Request("GET", "https://api.runpod.ai/v2/ep-1/status/j-1")
+        response = httpx.Response(401, request=request)
+        ep._api_get = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "401 unauthorized", request=request, response=response
+            )
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await job.wait()
+
+        # exactly one call: not retried
+        assert ep._api_get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_still_authoritative(self):
+        """when deadline is hit before threshold, raise TimeoutError not httpx error."""
+        import httpx
+
+        ep, job = self._make_job()
+        ep._api_get = AsyncMock(
+            side_effect=httpx.RemoteProtocolError("server disconnected")
+        )
+
+        with pytest.raises(TimeoutError, match="did not complete within"):
+            await job.wait(timeout=0.1)
+
+
 # -- Endpoint.run / runsync / cancel --
 
 


### PR DESCRIPTION
## Summary

- `EndpointJob.wait()` previously called `self.status()` with zero exception handling, so a single transient `httpx.RemoteProtocolError` (or any transport/timeout failure) on the Runpod `/v2/{id}/status/{job_id}` poll aborted the whole wait — even though the underlying job was still healthy. Cold starts (model download, vLLM compile, CUDA graph capture) make this very visible: one dropped poll fails a five-minute wait that was nearly complete.
- The polling loop now catches `httpx.TransportError` and `httpx.TimeoutException`, logs at debug, applies the existing exponential backoff, and continues. It re-raises only when the user-supplied `timeout` deadline is exceeded (still `TimeoutError`), or when `_POLL_MAX_CONSECUTIVE_ERRORS` (5) consecutive failures hit — so genuinely dead endpoints still fail loud. The counter resets on any successful poll.
- `httpx.HTTPStatusError` (4xx auth/config bugs from `raise_for_status`) is intentionally NOT caught — it propagates immediately.
- The user-space `_wait_resilient` workaround in `flash-examples/02_ml_inference/02_vllm_chat/vllm_chat.py` is now obsolete; cleanup of that file is intentionally out of scope for this PR.

Refs [AE-3154](https://linear.app/runpod/issue/AE-3154).

## Test plan

- [x] `make quality-check` passes (all tests + lint/format, coverage 85.45%).
- [x] New unit tests in `tests/unit/test_endpoint_client.py::TestEndpointJobWaitTransientErrors`:
  - transient `RemoteProtocolError` once, then `COMPLETED` — `wait()` returns normally (2 polls).
  - persistent `RemoteProtocolError` — `wait()` re-raises after `_POLL_MAX_CONSECUTIVE_ERRORS` polls.
  - error / success / error burst / success / `COMPLETED` — counter resets, `wait()` completes.
  - `HTTPStatusError(401)` is NOT swallowed; re-raised on first call.
  - `RemoteProtocolError` forever + `timeout=0.1` — `wait()` raises `TimeoutError`, not the httpx error.
- [ ] Manual smoke against an endpoint with cold workers (vLLM): `await job.wait()` survives mid-poll TCP drops instead of aborting.