### PR TITLE
feat: add agent source tracking to user-agent header

### DIFF
--- a/src/runpod_flash/core/utils/user_agent.py
+++ b/src/runpod_flash/core/utils/user_agent.py
@@ -1,10 +1,14 @@
 """User-Agent header generation for HTTP requests."""
 
+import os
 import platform
 
 
 def get_user_agent() -> str:
     """Get the User-Agent string for flash HTTP requests.
+
+    Appends coding agent source tags when the corresponding environment
+    variables are set (e.g. CLAUDECODE=1 for Claude Code).
 
     Returns:
         User-Agent string in format: Runpod Flash/<version> (Python <python_version>; <OS> <OS_version>; <arch>)
@@ -20,4 +24,9 @@ def get_user_agent() -> str:
     os_version = platform.release()
     arch = platform.machine()
 
-    return f"Runpod Flash/{__version__} (Python {python_version}; {os_name} {os_version}; {arch})"
+    ua = f"Runpod Flash/{__version__} (Python {python_version}; {os_name} {os_version}; {arch})"
+
+    if os.getenv("CLAUDECODE") == "1":
+        ua += " (via claude-code)"
+
+    return ua

--- a/tests/unit/core/utils/test_user_agent.py
+++ b/tests/unit/core/utils/test_user_agent.py
@@ -1,14 +1,18 @@
 """Tests for user_agent module."""
 
+import os
 import platform
 import re
+from unittest.mock import patch
 
 
 def test_get_user_agent_format():
     """Test User-Agent string format matches expected pattern."""
     from runpod_flash.core.utils.user_agent import get_user_agent
 
-    ua = get_user_agent()
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("CLAUDECODE", None)
+        ua = get_user_agent()
 
     # Should match: "Runpod Flash/<version> (Python <py_version>; <OS> <OS_version>; <arch>)"
     pattern = r"^Runpod Flash/[\w\.]+ \(Python [\d\.]+; \w+ [\w\.\-]+; [\w\d_]+\)$"
@@ -79,7 +83,9 @@ def test_get_user_agent_structure():
     """Test User-Agent has correct structure."""
     from runpod_flash.core.utils.user_agent import get_user_agent
 
-    ua = get_user_agent()
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("CLAUDECODE", None)
+        ua = get_user_agent()
 
     # Should have exactly one opening and closing parenthesis
     assert ua.count("(") == 1, "User-Agent should have exactly one opening parenthesis"
@@ -97,3 +103,28 @@ def test_get_user_agent_consistency():
     ua2 = get_user_agent()
 
     assert ua1 == ua2, "User-Agent should be consistent across calls"
+
+
+def test_get_user_agent_with_claude_code():
+    """Test User-Agent includes claude-code agent tag."""
+    from runpod_flash.core.utils.user_agent import get_user_agent
+
+    with patch.dict(os.environ, {"CLAUDECODE": "1"}):
+        ua = get_user_agent()
+
+    assert ua.endswith("(via claude-code)"), (
+        f"User-Agent should end with '(via claude-code)', got: {ua}"
+    )
+
+
+def test_get_user_agent_without_claude_code():
+    """Test User-Agent excludes agent tag when env var is not set."""
+    from runpod_flash.core.utils.user_agent import get_user_agent
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("CLAUDECODE", None)
+        ua = get_user_agent()
+
+    assert "via claude-code" not in ua, (
+        f"User-Agent should not contain agent tag, got: {ua}"
+    )


### PR DESCRIPTION
Appends coding agent source tags to the User-Agent string on all outgoing API requests when the corresponding environment variable is set (e.g. `CLAUDECODE=1` adds `(via claude-code)`). Propagates through all HTTP client factories (httpx, requests, aiohttp).

CON-85