### PR TITLE
feat(sdk): make endpoint/app lifecycle operations CLI-only

### DIFF
--- a/src/runpod_flash/cli/main.py
+++ b/src/runpod_flash/cli/main.py
@@ -17,6 +17,7 @@ from .commands import (
     update,
 )
 from .update_checker import start_background_check
+from ..core.cli_context import mark_cli_invocation
 
 
 def get_version() -> str:
@@ -78,6 +79,11 @@ def main(
     version: bool = typer.Option(False, "--version", "-v", help="Show version"),
 ):
     """Runpod Flash CLI - Distributed inference and serving framework."""
+    # Mark this process as a CLI invocation so resource lifecycle operations
+    # (deploy/undeploy/app/env management) are permitted. Direct SDK calls
+    # outside the CLI raise FlashUsageError. See core.cli_context.
+    mark_cli_invocation()
+
     if version:
         console.print(f"Runpod Flash CLI v{get_version()}")
         raise typer.Exit()

--- a/src/runpod_flash/core/cli_context.py
+++ b/src/runpod_flash/core/cli_context.py
@@ -1,0 +1,97 @@
+"""CLI-invocation context for guarding lifecycle operations.
+
+Endpoint/app lifecycle operations (deploy, undeploy, update, app/environment
+management) are managed by the flash CLI, which orchestrates the build/manifest
+pipeline and records local state. Calling those methods directly from the SDK
+skips that orchestration and leaves state inconsistent.
+
+This module provides a process-scoped flag, set once at the CLI entry point, and
+a `cli_only` decorator that raises :class:`FlashUsageError` when a guarded method
+is called outside that context. `allow_lifecycle_operations` is the sanctioned
+escape hatch for first-party code (e.g. tests) that must drive lifecycle without
+going through the CLI process.
+
+Why a ContextVar and not an env var: it propagates automatically into the
+asyncio task spawned by the CLI command (`asyncio.run` copies the current
+context), needs no cleanup in a one-shot CLI process, and is trivially scoped in
+tests via `allow_lifecycle_operations`.
+"""
+
+import functools
+from collections.abc import Awaitable, Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TypeVar
+
+from .exceptions import FlashUsageError
+
+_invoked_by_cli: ContextVar[bool] = ContextVar("flash_invoked_by_cli", default=False)
+
+_T = TypeVar("_T")
+
+
+def mark_cli_invocation() -> None:
+    """Mark the current context as a flash CLI invocation.
+
+    Called once from the CLI entry point. Set-and-leave: a Typer callback returns
+    before the command runs, so a context-manager scope cannot wrap the command.
+    A plain set is correct for a one-shot CLI process and propagates into the
+    command's ``asyncio.run()`` context.
+    """
+    _invoked_by_cli.set(True)
+
+
+def is_cli_invocation() -> bool:
+    """Return whether lifecycle operations are currently permitted."""
+    return _invoked_by_cli.get()
+
+
+@contextmanager
+def allow_lifecycle_operations():
+    """Permit guarded lifecycle operations within this block.
+
+    Sanctioned escape hatch for first-party code that must drive resource
+    lifecycle without going through the CLI process (notably tests). Restores the
+    previous state on exit.
+
+    Example:
+        with allow_lifecycle_operations():
+            await endpoint.deploy()
+    """
+    token = _invoked_by_cli.set(True)
+    try:
+        yield
+    finally:
+        _invoked_by_cli.reset(token)
+
+
+def cli_only(
+    cli_command: str,
+) -> Callable[[Callable[..., Awaitable[_T]]], Callable[..., Awaitable[_T]]]:
+    """Restrict an async lifecycle method to flash CLI invocation.
+
+    Args:
+        cli_command: The equivalent flash CLI command, surfaced in the error
+            (e.g. ``"flash deploy"``).
+
+    Raises:
+        FlashUsageError: When the decorated method is called outside a CLI
+            context or an :func:`allow_lifecycle_operations` block.
+    """
+
+    def decorator(func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]:
+        @functools.wraps(func)
+        async def wrapper(*args: object, **kwargs: object) -> _T:
+            if not _invoked_by_cli.get():
+                raise FlashUsageError(
+                    f"{func.__qualname__}() is a CLI-managed operation and cannot "
+                    f"be called directly from the SDK.\n\n"
+                    f"    Use:  {cli_command}\n\n"
+                    "Direct SDK calls bypass flash's build/manifest pipeline and "
+                    "local state tracking, leaving deployments inconsistent."
+                )
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/runpod_flash/core/exceptions.py
+++ b/src/runpod_flash/core/exceptions.py
@@ -4,7 +4,24 @@ Provides clear, actionable error messages for common failure scenarios.
 """
 
 
-class RunpodAPIKeyError(Exception):
+class FlashError(Exception):
+    """Base class for all runpod_flash domain errors.
+
+    Catch this to handle any flash-raised error; catch a subclass for a
+    specific failure mode.
+    """
+
+
+class FlashUsageError(FlashError):
+    """Raised when the SDK is used in a way that is not supported.
+
+    Currently raised when a CLI-managed lifecycle operation (deploy, undeploy,
+    app/environment management) is invoked directly from the SDK instead of
+    through the flash CLI. The message names the equivalent CLI command.
+    """
+
+
+class RunpodAPIKeyError(FlashError):
     """Raised when RUNPOD_API_KEY environment variable is missing or invalid.
 
     This exception provides helpful guidance on how to obtain and configure

--- a/src/runpod_flash/core/resources/app.py
+++ b/src/runpod_flash/core/resources/app.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional, Union, Tuple, TYPE_CHECKING, Any, List
 import logging
 
 from ..api.runpod import RunpodGraphQLClient
+from ..cli_context import cli_only
 
 from .constants import (
     TARBALL_CONTENT_TYPE,
@@ -325,6 +326,7 @@ class FlashApp:
             self._hydrated = True
             return
 
+    @cli_only("flash env create")
     async def create_environment(self, environment_name: str) -> Dict[str, Any]:
         """Create an environment within an app.
 
@@ -362,6 +364,7 @@ class FlashApp:
                 {"flashAppId": self.id, "tarballSize": tarball_size}
             )
 
+    @cli_only("flash deploy")
     async def deploy_build_to_environment(
         self,
         build_id: str,
@@ -494,12 +497,14 @@ class FlashApp:
         return cls(app_name, id=result["id"], eager_hydrate=False)
 
     @classmethod
+    @cli_only("flash app create")
     async def create(cls, app_name: str) -> "FlashApp":
         async with RunpodGraphQLClient() as client:
             result = await client.create_flash_app({"name": app_name})
         return cls(app_name, id=result["id"], eager_hydrate=False)
 
     @classmethod
+    @cli_only("flash app create")
     async def get_or_create(cls, app_name: str) -> "FlashApp":
         try:
             return await cls.from_name(app_name)
@@ -509,6 +514,7 @@ class FlashApp:
             return cls(app_name, id=result["id"], eager_hydrate=False)
 
     @classmethod
+    @cli_only("flash app create")
     async def create_environment_and_app(
         cls, app_name: str, environment_name: str
     ) -> Tuple["FlashApp", Dict]:
@@ -522,6 +528,7 @@ class FlashApp:
             return await client.list_flash_apps()
 
     @classmethod
+    @cli_only("flash app delete")
     async def delete(
         cls, app_name: Optional[str] = None, app_id: Optional[str] = None
     ) -> bool:
@@ -540,6 +547,7 @@ class FlashApp:
             result = await client.delete_flash_app(app_id)
         return result.get("success", False)
 
+    @cli_only("flash env delete")
     async def delete_environment(self, environment_name: str) -> bool:
         """Delete an environment from this flash app.
 

--- a/src/runpod_flash/core/resources/load_balancer_sls_resource.py
+++ b/src/runpod_flash/core/resources/load_balancer_sls_resource.py
@@ -45,7 +45,8 @@ class LoadBalancerSlsResource(ServerlessResource):
             workersMin=1,
             workersMax=3,
         )
-        await lb.deploy()
+
+    Deploy via the CLI (`flash deploy`); SDK lifecycle calls are CLI-only.
     """
 
     # Override default type to LB
@@ -209,7 +210,8 @@ class CpuLoadBalancerSlsResource(CpuEndpointMixin, LoadBalancerSlsResource):
             workersMin=1,
             workersMax=3,
         )
-        await cpu_lb.deploy()
+
+    Deploy via the CLI (`flash deploy`); SDK lifecycle calls are CLI-only.
     """
 
     instanceIds: Optional[List[CpuInstanceType]] = [CpuInstanceType.CPU3G_2_8]

--- a/src/runpod_flash/core/resources/network_volume.py
+++ b/src/runpod_flash/core/resources/network_volume.py
@@ -15,6 +15,7 @@ from ..api.runpod import RunpodRestClient
 from ..urls import RUNPOD_CONSOLE_URL
 from .base import DeployableResource
 from .resource_manager import ResourceManager
+from ..cli_context import cli_only
 
 log = logging.getLogger(__name__)
 
@@ -214,6 +215,7 @@ class NetworkVolume(DeployableResource):
             log.error(f"{self} failed to deploy: {e}")
             raise
 
+    @cli_only("flash deploy")
     async def deploy(self) -> "DeployableResource":
         resource_manager = ResourceManager()
         resource = await resource_manager.get_or_deploy_resource(self)

--- a/src/runpod_flash/core/resources/serverless.py
+++ b/src/runpod_flash/core/resources/serverless.py
@@ -20,6 +20,7 @@ from pydantic import (
 from runpod.endpoint.runner import Job
 
 from ..api.runpod import RunpodGraphQLClient
+from ..cli_context import cli_only
 from ..exceptions import RunpodAPIKeyError
 from ..utils.backoff import get_backoff_delay
 from .base import DeployableResource
@@ -1114,6 +1115,7 @@ class ServerlessResource(DeployableResource):
             log.error(f"{self} failed to deploy: {e}")
             raise
 
+    @cli_only("flash deploy")
     async def update(self, new_config: "ServerlessResource") -> "ServerlessResource":
         """Update existing endpoint with new configuration.
 
@@ -1317,6 +1319,7 @@ class ServerlessResource(DeployableResource):
 
         return False
 
+    @cli_only("flash deploy")
     async def deploy(self) -> "DeployableResource":
         resource_manager = ResourceManager()
         resource = await resource_manager.get_or_deploy_resource(self)
@@ -1369,6 +1372,7 @@ class ServerlessResource(DeployableResource):
 
             return False
 
+    @cli_only("flash undeploy")
     async def undeploy(self) -> Dict[str, Any]:
         resource_manager = ResourceManager()
         result = await resource_manager.undeploy_resource(self.resource_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from runpod_flash.core.cli_context import allow_lifecycle_operations
 from runpod_flash.core.resources.resource_manager import ResourceManager
 from runpod_flash.core.utils.singleton import SingletonMixin
 
@@ -29,6 +30,26 @@ def pytest_configure(config):
     """
     # This hook is called early in pytest initialization
     # xdist will check for this during test distribution
+    config.addinivalue_line(
+        "markers",
+        "no_cli_context: run with the flash CLI context disabled so guarded "
+        "lifecycle methods raise FlashUsageError (used by guard tests).",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _flash_cli_context(request):
+    """Permit CLI-managed lifecycle operations during tests.
+
+    Lifecycle methods (deploy/undeploy/app/env management) are restricted to
+    flash CLI invocation. Most tests drive them directly, so enable the context
+    by default. Guard tests opt out with @pytest.mark.no_cli_context.
+    """
+    if request.node.get_closest_marker("no_cli_context"):
+        yield
+    else:
+        with allow_lifecycle_operations():
+            yield
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from runpod_flash.core.cli_context import allow_lifecycle_operations
+from runpod_flash.core.cli_context import _invoked_by_cli, allow_lifecycle_operations
 from runpod_flash.core.resources.resource_manager import ResourceManager
 from runpod_flash.core.utils.singleton import SingletonMixin
 
@@ -44,9 +44,19 @@ def _flash_cli_context(request):
     Lifecycle methods (deploy/undeploy/app/env management) are restricted to
     flash CLI invocation. Most tests drive them directly, so enable the context
     by default. Guard tests opt out with @pytest.mark.no_cli_context.
+
+    The opt-out branch actively forces the context to False (rather than merely
+    skipping the enable) and restores it afterwards. ``mark_cli_invocation()`` is
+    set-and-leave, so a CLI test that ran earlier in the same worker could leave
+    the ContextVar True; forcing False here makes guard tests independent of test
+    order instead of relying on each guard module to reset the var itself.
     """
     if request.node.get_closest_marker("no_cli_context"):
-        yield
+        token = _invoked_by_cli.set(False)
+        try:
+            yield
+        finally:
+            _invoked_by_cli.reset(token)
     else:
         with allow_lifecycle_operations():
             yield

--- a/tests/unit/core/test_cli_context.py
+++ b/tests/unit/core/test_cli_context.py
@@ -12,21 +12,13 @@ from runpod_flash.core.cli_context import (
     cli_only,
     is_cli_invocation,
     mark_cli_invocation,
-    _invoked_by_cli,
 )
 from runpod_flash.core.exceptions import FlashError, FlashUsageError
 
+# The conftest ``_flash_cli_context`` fixture forces the CLI context to False for
+# every no_cli_context test and restores it afterwards, so these tests start from
+# a clean default regardless of order.
 pytestmark = pytest.mark.no_cli_context
-
-
-@pytest.fixture(autouse=True)
-def _reset_cli_context():
-    """Guarantee a clean default (False) context around each test."""
-    token = _invoked_by_cli.set(False)
-    try:
-        yield
-    finally:
-        _invoked_by_cli.reset(token)
 
 
 @cli_only("flash deploy")

--- a/tests/unit/core/test_cli_context.py
+++ b/tests/unit/core/test_cli_context.py
@@ -1,0 +1,120 @@
+"""Tests for the CLI-invocation guard on lifecycle operations.
+
+These tests run with the flash CLI context DISABLED (@pytest.mark.no_cli_context)
+so that guarded methods raise FlashUsageError, mirroring direct SDK use outside
+the CLI. The autouse fixture in conftest enables the context for all other tests.
+"""
+
+import pytest
+
+from runpod_flash.core.cli_context import (
+    allow_lifecycle_operations,
+    cli_only,
+    is_cli_invocation,
+    mark_cli_invocation,
+    _invoked_by_cli,
+)
+from runpod_flash.core.exceptions import FlashError, FlashUsageError
+
+pytestmark = pytest.mark.no_cli_context
+
+
+@pytest.fixture(autouse=True)
+def _reset_cli_context():
+    """Guarantee a clean default (False) context around each test."""
+    token = _invoked_by_cli.set(False)
+    try:
+        yield
+    finally:
+        _invoked_by_cli.reset(token)
+
+
+@cli_only("flash deploy")
+async def _guarded(value: int) -> int:
+    return value * 2
+
+
+class TestCliOnlyDecorator:
+    async def test_raises_outside_cli_context(self):
+        with pytest.raises(FlashUsageError):
+            await _guarded(21)
+
+    async def test_runs_inside_allow_block(self):
+        with allow_lifecycle_operations():
+            assert await _guarded(21) == 42
+
+    async def test_runs_after_mark_cli_invocation(self):
+        mark_cli_invocation()
+        assert await _guarded(21) == 42
+
+    async def test_message_names_method_and_cli_command(self):
+        with pytest.raises(FlashUsageError) as exc:
+            await _guarded(1)
+        message = str(exc.value)
+        assert "_guarded" in message
+        assert "flash deploy" in message
+
+    async def test_flash_usage_error_is_flash_error(self):
+        assert issubclass(FlashUsageError, FlashError)
+
+
+class TestRealMethodsGuarded:
+    """The guard runs before the method body, so a dummy ``self`` is enough to
+    prove each real lifecycle method is decorated without constructing resources.
+    """
+
+    async def test_serverless_lifecycle_methods_guarded(self):
+        from runpod_flash.core.resources.serverless import ServerlessResource
+
+        with pytest.raises(FlashUsageError):
+            await ServerlessResource.deploy(object())
+        with pytest.raises(FlashUsageError):
+            await ServerlessResource.undeploy(object())
+        with pytest.raises(FlashUsageError):
+            await ServerlessResource.update(object(), object())
+
+    async def test_network_volume_deploy_guarded(self):
+        from runpod_flash.core.resources.network_volume import NetworkVolume
+
+        with pytest.raises(FlashUsageError):
+            await NetworkVolume.deploy(object())
+
+    async def test_flash_app_classmethods_guarded(self):
+        from runpod_flash.core.resources.app import FlashApp
+
+        with pytest.raises(FlashUsageError):
+            await FlashApp.create("app")
+        with pytest.raises(FlashUsageError):
+            await FlashApp.get_or_create("app")
+        with pytest.raises(FlashUsageError):
+            await FlashApp.create_environment_and_app("app", "env")
+        with pytest.raises(FlashUsageError):
+            await FlashApp.delete(app_name="app")
+
+    async def test_flash_app_instance_methods_guarded(self):
+        from runpod_flash.core.resources.app import FlashApp
+
+        with pytest.raises(FlashUsageError):
+            await FlashApp.create_environment(object(), "env")
+        with pytest.raises(FlashUsageError):
+            await FlashApp.delete_environment(object(), "env")
+        with pytest.raises(FlashUsageError):
+            await FlashApp.deploy_build_to_environment(object(), "build-id")
+
+
+class TestContextHelpers:
+    def test_default_is_not_cli(self):
+        assert is_cli_invocation() is False
+
+    def test_allow_block_toggles_and_restores(self):
+        assert is_cli_invocation() is False
+        with allow_lifecycle_operations():
+            assert is_cli_invocation() is True
+        assert is_cli_invocation() is False
+
+    def test_nested_allow_blocks_restore_correctly(self):
+        with allow_lifecycle_operations():
+            with allow_lifecycle_operations():
+                assert is_cli_invocation() is True
+            assert is_cli_invocation() is True
+        assert is_cli_invocation() is False


### PR DESCRIPTION
## Summary

Makes endpoint/app lifecycle operations CLI-only at the SDK level. Direct SDK calls now raise `FlashUsageError` naming the equivalent `flash` CLI command, instead of silently bypassing the CLI's build/manifest pipeline and local state tracking (which leaves deployments inconsistent — e.g. a stale endpoint when `delete_endpoint()` is used instead of `flash undeploy`).

The CLI marks its own process context once in the Typer callback, so CLI commands and internal composition are permitted. The runtime (deployed workers) is unaffected — it never calls these methods.

## Changes

- **`core/cli_context.py`** (new): process-scoped `ContextVar` flag, `mark_cli_invocation()`, `allow_lifecycle_operations()` escape hatch, and a `cli_only()` decorator.
- **`core/exceptions.py`**: add `FlashError` base + `FlashUsageError`; reparent `RunpodAPIKeyError` under `FlashError`.
- **`cli/main.py`**: call `mark_cli_invocation()` in the Typer callback (single chokepoint).
- **Guards** (`@cli_only`): `ServerlessResource.{deploy,undeploy,update}` (covers all serverless/LB/CPU subclasses via inheritance — no overrides), `NetworkVolume.deploy`, and `FlashApp` create/delete/environment methods.
- **Tests**: `tests/unit/core/test_cli_context.py` + autouse conftest fixture enabling the context for the suite (`no_cli_context` marker opts guard tests out).

## Design notes

- Not literal `private`/name-mangling: these methods are called by the CLI and by internal composition, so renaming churns call sites and provides no real protection. The context guard enforces intent without breaking internal use.
- `ResourceManager` is intentionally **not** guarded — it is only reached after a resource-level guard passes or directly from CLI code, and the runtime never calls it for lifecycle.
- Set-and-leave flag (not a `with` block): a Typer callback returns before the command runs, so it can't wrap the command; a plain set propagates into the command's `asyncio.run` context.

## Test plan

- [x] `make quality-check` passes (lint + mypy + coverage 86%)
- [x] Full suite: 2627 passed, 2 skipped, 1 xfailed
- [x] 12 new guard tests (decorator, context helpers, real guarded methods)
- [x] End-to-end: CLI imports clean; a guarded method called outside the CLI raises `FlashUsageError` with the equivalent CLI command in the message
