### PR TITLE
ci: add automated Linear release tracking (SLS-163)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,7 @@ jobs:
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - name: Generate GitHub App Token
@@ -69,3 +70,36 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+
+  # Linear release tracking (SLS-163)
+  linear-sync:
+    name: Linear Release Sync
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: sync
+          version: ${{ needs.release-please.outputs.tag_name }}
+          name: ${{ needs.release-please.outputs.tag_name && format('flash {0}', needs.release-please.outputs.tag_name) || '' }}
+
+  linear-complete:
+    name: Linear Release Complete
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs: [release-please, linear-sync]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: complete
+          version: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,6 +76,8 @@ jobs:
     name: Linear Release Sync
     needs: release-please
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,6 +95,8 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     needs: [release-please, linear-sync]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           verbose: true
 
-  # Linear release tracking (SLS-163)
+  # Linear release tracking
   linear-sync:
     name: Linear Release Sync
     needs: release-please


### PR DESCRIPTION
Adds `linear-sync` + `linear-complete` jobs to `.github/workflows/release-please.yml`, keyed off `release-please`. Also exposes the `tag_name` output from the release-please step so it can be passed as the Linear release version/name.
## Requirements
- Repo/org secret **`LINEAR_RELEASE_ACCESS_KEY`** must be set (same secret already used by `main-ui`).

Implements SLS-163 (part of SLS-160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)